### PR TITLE
Update German translations

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -9,10 +9,10 @@
     <string name="error_media_upload_permission">Eine Leseberechtigung wird für das Hochladen der Mediendatei benötigt.</string>
     <string name="error_media_upload_image_or_video">Bilder und Videos können beide nicht an den Status angehängt werden.</string>
     <string name="error_media_upload_sending">Die Mediendatei konnte nicht hochgeladen werden.</string>
-    <string name="error_following">Diesem Benutzer wurde nie gefolgt.</string>
-    <string name="error_unfollowing">Dieser Benutzer war nie entfolgt.</string>
-    <string name="error_blocking">Dieser Benutzer war nie blockiert.</string>
-    <string name="error_unblocking">Dieser Benutzer war nie freigegeben.</string>
+    <string name="error_following">Dem Benutzer wurde nicht gefolgt.</string>
+    <string name="error_unfollowing">Dieser Benutzer wurde nicht entfolgt.</string>
+    <string name="error_blocking">Dieser Benutzer wurde nicht blockiert.</string>
+    <string name="error_unblocking">Dieser Benutzer wurde nicht entblockt.</string>
     <string name="error_view_thread">Konnte diese Unterhaltung nicht empfangen.</string>
     <string name="error_obtain_account">Fehler beim Laden des Accounts.</string>
     <string name="error_report_unsent">Dieser Bericht konnte nicht gesendet werden.</string>
@@ -35,16 +35,16 @@
     <string name="status_content_warning_show_more">Zeige mehr</string>
     <string name="status_content_warning_show_less">Zeige weniger</string>
 
-    <string name="footer_retry_statuses">Konnte den Rest der Statuse nicht laden.</string>
+    <string name="footer_retry_statuses">Konnte den Rest der Status nicht laden.</string>
     <string name="footer_retry_notifications">Konnte den Rest der Benachrichtigungen nicht laden.</string>
     <string name="footer_retry_accounts">Konnte den Rest der Accounts nicht laden.</string>
-    <string name="footer_end_of_statuses">Ende der Statuse</string>
+    <string name="footer_end_of_statuses">Ende der Status</string>
     <string name="footer_end_of_notifications">Ende der Benachrichtigungen</string>
     <string name="footer_end_of_accounts">Ende der Accounts</string>
 
     <string name="notification_reblog_format">%s teilte deinen Status</string>
     <string name="notification_favourite_format">%s favorisierte deinen Status</string>
-    <string name="notification_follow_format">%s ist dir gefolgt</string>
+    <string name="notification_follow_format">%s folgt dir</string>
 
     <string name="report_username_format">\@%s melden</string>
     <string name="report_comment_hint">Irgendwelche Anmerkungen?</string>
@@ -55,13 +55,13 @@
     <string name="action_follow">Folgen</string>
     <string name="action_unfollow">Entfolgen</string>
     <string name="action_block">Blockieren</string>
-    <string name="action_unblock">Freigeben</string>
+    <string name="action_unblock">Entblockieren</string>
     <string name="action_report">Melden</string>
     <string name="action_delete">Löschen</string>
     <string name="action_send">TOOT</string>
     <string name="action_send_public">TOOT!</string>
     <string name="action_retry">Erneut versuchen</string>
-    <string name="action_mark_sensitive">Markiere Mediendatei als sensibel</string>
+    <string name="action_mark_sensitive">Markiere Mediendatei als heikel</string>
     <string name="action_hide_text">Verstecke Text hinter Warnung</string>
     <string name="action_ok">Ok</string>
     <string name="action_cancel">Abbrechen</string>
@@ -90,11 +90,11 @@
         <a href="https://mastodon.social/about">mastodon.social</a>.
     </string>
     <string name="dialog_title_finishing_media_upload">Stelle Medienupload fertig</string>
-    <string name="dialog_message_uploading_media">Lädt hoch…</string>
+    <string name="dialog_message_uploading_media">Lade hoch…</string>
 
-    <string name="visibility_public">Jeder darf sehen</string>
-    <string name="visibility_unlisted">Jeder darf sehen, aber nicht in der öffentlichen Timeline</string>
-    <string name="visibility_private">Nur Follower und Erwähnte dürfen sehen</string>
+    <string name="visibility_public">Öffentlich sichtbar</string>
+    <string name="visibility_unlisted">Öffentlich sichtbar, aber nicht in der öffentlichen Timeline</string>
+    <string name="visibility_private">Nur für Follower und Erwähnte sichtbar</string>
 
     <string name="pref_title_notification_settings">Benachrichtigungen</string>
     <string name="pref_title_notification_alert_sound">Benachrichtige mit Sound</string>
@@ -110,8 +110,8 @@
     <string name="send_status_to">Teile Toot-URL zu…</string>
     <string name="action_mute">Stummschalten</string>
     <string name="action_unmute">Lautschalten</string>
-    <string name="error_unmuting">Dieser Benutzer war nie lautgeschaltet.</string>
-    <string name="error_muting">Dieser Benutzer war nie stummgeschaltet.</string>
+    <string name="error_unmuting">Dieser Benutzer wurde nicht lautgeschaltet.</string>
+    <string name="error_muting">Dieser Benutzer wurde nicht stummgeschaltet.</string>
     <string name="search">Suche Accounts…</string>
     <string name="toggle_nsfw">NSFW</string>
     <string name="action_mention">Erwähnen</string>


### PR DESCRIPTION
* The plural of Status is Status (pronounced differently, tho), not Statuse, see https://de.wiktionary.org/wiki/Status - Not just for that reason, I suggest to remove the word *Status* completely and use *Toot* or *Toots* instead
* "Dieser Benutzer war nie *x*" translates to "This user was never *x*". The new translations are similar to the English ones, but I'd prefer something like "Couldn't follow that user".
* "%s ist dir gefolgt" -> "%s was following you"
* With the visibility I took more freedom and translated them "Public visible", "Public visible, but not in the public timeline" and "Only visible to followers and mentioned"