### PR TITLE
[fixed] add support for downloading images

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.VIBRATE" />
 
     <application

--- a/app/src/main/java/com/keylesspalace/tusky/MainActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/MainActivity.java
@@ -24,8 +24,10 @@ import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.PersistableBundle;
+import android.support.annotation.NonNull;
 import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.TabLayout;
+import android.support.v4.app.Fragment;
 import android.support.v4.view.ViewPager;
 import android.text.SpannableStringBuilder;
 import android.text.Spanned;
@@ -435,6 +437,17 @@ public class MainActivity extends BaseActivity {
         } else {
             pageHistory.pop();
             viewPager.setCurrentItem(pageHistory.peek());
+        }
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        List<Fragment> fragments = getSupportFragmentManager().getFragments();
+        if (fragments != null) {
+            for (Fragment fragment : fragments) {
+                fragment.onRequestPermissionsResult(requestCode, permissions, grantResults);
+            }
         }
     }
 }

--- a/app/src/main/java/com/keylesspalace/tusky/ViewMediaFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/ViewMediaFragment.java
@@ -15,7 +15,13 @@
 
 package com.keylesspalace.tusky;
 
+import android.app.AlertDialog;
+import android.app.DownloadManager;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.net.Uri;
 import android.os.Bundle;
+import android.os.Environment;
 import android.support.annotation.Nullable;
 import android.support.v4.app.DialogFragment;
 import android.view.LayoutInflater;
@@ -27,6 +33,8 @@ import android.view.WindowManager;
 import com.squareup.picasso.Callback;
 import com.squareup.picasso.Picasso;
 
+import java.io.File;
+
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import uk.co.senab.photoview.PhotoView;
@@ -35,7 +43,7 @@ import uk.co.senab.photoview.PhotoViewAttacher;
 public class ViewMediaFragment extends DialogFragment {
 
     private PhotoViewAttacher attacher;
-
+    private DownloadManager downloadManager;
     @BindView(R.id.view_media_image) PhotoView photoView;
 
     public static ViewMediaFragment newInstance(String url) {
@@ -95,6 +103,37 @@ public class ViewMediaFragment extends DialogFragment {
                     dismiss();
                     return true;
                 }
+                return false;
+            }
+        });
+
+        attacher.setOnLongClickListener(new View.OnLongClickListener() {
+            @Override
+            public boolean onLongClick(View v) {
+
+                AlertDialog downloadDialog = new AlertDialog.Builder(getContext()).create();
+
+                downloadDialog.setButton(AlertDialog.BUTTON_NEUTRAL, getString(R.string.dialog_download_image),
+                        new DialogInterface.OnClickListener() {
+                            public void onClick(DialogInterface dialog, int which) {
+                                dialog.dismiss();
+
+                                String url = getArguments().getString("url");
+                                Uri uri = Uri.parse(url);
+
+                                String filename = new File(url).getName();
+
+                                downloadManager = (DownloadManager) getContext().getSystemService(Context.DOWNLOAD_SERVICE);
+
+                                DownloadManager.Request request = new DownloadManager.Request(uri);
+                                request.allowScanningByMediaScanner();
+                                request.setDestinationInExternalPublicDir(Environment.DIRECTORY_PICTURES, getString(R.string.app_name) + "/" + filename);
+
+                                downloadManager.enqueue(request);
+                                System.out.println(url);
+                            }
+                        });
+                downloadDialog.show();
                 return false;
             }
         });

--- a/app/src/main/java/com/keylesspalace/tusky/ViewMediaFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/ViewMediaFragment.java
@@ -15,7 +15,6 @@
 
 package com.keylesspalace.tusky;
 
-import android.*;
 import android.app.AlertDialog;
 import android.app.DownloadManager;
 import android.content.Context;
@@ -29,7 +28,6 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
 import android.support.design.widget.Snackbar;
-import android.support.v13.app.ActivityCompat;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.content.ContextCompat;
 import android.view.LayoutInflater;
@@ -42,7 +40,6 @@ import com.squareup.picasso.Callback;
 import com.squareup.picasso.Picasso;
 
 import java.io.File;
-import java.security.Permission;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -161,10 +158,6 @@ public class ViewMediaFragment extends DialogFragment {
         super.onDestroyView();
     }
 
-    /**
-     * Check permissions and download the thing at getArguments().getString("url") as image, listed in the systems gallery.
-     * This works in general, but when the permission is granted at runtime, the download button ha to be pressed again (see comment further down)
-     */
     private void downloadImage(){
 
         //Permission stuff
@@ -194,21 +187,15 @@ public class ViewMediaFragment extends DialogFragment {
         }
     }
 
-    /*
-     * took this from ComposeActivity.java (Media upload) to handle permission requests.
-     * However, onRequestPermissionResult seems not to be called.
-     */
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String permissions[],
                                            @NonNull int[] grantResults) {
-        System.out.println("Requestcode: " + requestCode);
         switch (requestCode) {
             case PERMISSIONS_REQUEST_WRITE_EXTERNAL_STORAGE: {
                 if (grantResults.length > 0
                         && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                     downloadImage();
                 } else {
-                    System.out.println("not granted\n");
                     doErrorDialog(R.string.error_media_download_permission, R.string.action_retry,
                             new View.OnClickListener() {
                                 @Override
@@ -224,7 +211,7 @@ public class ViewMediaFragment extends DialogFragment {
 
     private void doErrorDialog(@StringRes int descriptionId, @StringRes int actionId,
                                View.OnClickListener listener) {
-        Snackbar bar = Snackbar.make(getActivity().findViewById(R.id.view_media_image), getString(descriptionId),
+        Snackbar bar = Snackbar.make(getView(), getString(descriptionId),
                 Snackbar.LENGTH_SHORT);
         bar.setAction(actionId, listener);
         bar.show();

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -121,5 +121,6 @@
     <string name="error_generic">Ein Fehler ist Aufgetreten.</string>
     <string name="error_no_web_browser_found">Kein Webbrowser gefunden.</string>
     <string name="error_retrieving_oauth_token">Es konnte kein Login-Token abgerufen werden.</string>
+    <string name="dialog_download_image">Herunterladen</string>
 
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -122,5 +122,6 @@
     <string name="error_no_web_browser_found">Kein Webbrowser gefunden.</string>
     <string name="error_retrieving_oauth_token">Es konnte kein Login-Token abgerufen werden.</string>
     <string name="dialog_download_image">Herunterladen</string>
+    <string name="error_media_download_permission">Eine Berechtigung wird zum Speichern des Mediums benötigt.</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,6 +12,8 @@
     <string name="error_media_upload_type">That type of file cannot be uploaded.</string>
     <string name="error_media_upload_opening">That file could not be opened.</string>
     <string name="error_media_upload_permission">Permission to read media is required.</string>
+    <string name="error_media_download_permission">Permission to store media is required.</string>
+
     <string name="error_media_upload_image_or_video">Images and videos cannot both be attached to the same status.</string>
     <string name="error_media_upload_sending">The upload failed.</string>
     <string name="error_report_too_few_statuses">At least one status must be reported.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -126,4 +126,5 @@
     <string name="notification_summary_small">%1$s and %2$s</string>
     <string name="notification_title_summary">%d new interactions</string>
 
+    <string name="dialog_download_image">Download</string>
 </resources>


### PR DESCRIPTION
hi,
I implemented downloading images by tap-and-hold on a fullscreen image. 📷 
The download itself is handled by androids DownloadManager, images are stored in Pictures/$app_name on the internal storage.
The filename is generated from the url, pictures appear in the systems gallery.
Runtime permissions are supported, but the error handling if it's not granted (like done with the media upload) is not yet working (see comments in the code).

~~Known issues: When the permission is granted at runtime, the download button has to be pressed again~~
Tested on: Android 7.0
Todos: ~~fix the issue,~~ preferences for storage location (internal or sd), translation

I will try to implement the preferences later ~~, but I think i'm not experienced enough for the permission-not-granted-thing.~~
Happy Coding 🤖 :3

Edit: I fixed the permission-thing (The onRequestPermissionResult is just called in the parent activity, so i forwarded it back to the Fragment)