### PR TITLE
inherit content warnings in replies

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/ComposeActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/ComposeActivity.java
@@ -369,6 +369,7 @@ public class  ComposeActivity extends BaseActivity implements ComposeOptionsFrag
 
         String startingVisibility;
         boolean startingHideText;
+        String startingContentWarning = null;
         ArrayList<SavedQueuedMedia> savedMediaQueued = null;
         if (savedInstanceState != null) {
             showMarkSensitive = savedInstanceState.getBoolean("showMarkSensitive");
@@ -411,6 +412,13 @@ public class  ComposeActivity extends BaseActivity implements ComposeOptionsFrag
             }
 
             mentionedUsernames = intent.getStringArrayExtra("mentioned_usernames");
+
+            if(inReplyToId != null) {
+                startingHideText = !intent.getStringExtra("content_warning").equals("");
+                if(startingHideText){
+                    startingContentWarning = intent.getStringExtra("content_warning");
+                }
+            }
         }
         /* Only after the starting visibility is determined and the send button is initialised can
          * the status visibility be set. */
@@ -475,6 +483,10 @@ public class  ComposeActivity extends BaseActivity implements ComposeOptionsFrag
             public void afterTextChanged(Editable s) {}
         });
         showContentWarning(startingHideText);
+
+        if(startingContentWarning != null){
+            contentWarningEditor.setText(startingContentWarning);
+        }
 
         statusAlreadyInFlight = false;
 

--- a/app/src/main/java/com/keylesspalace/tusky/SFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/SFragment.java
@@ -66,6 +66,7 @@ public class SFragment extends BaseFragment {
         String inReplyToId = status.getActionableId();
         Status actionableStatus = status.getActionableStatus();
         String replyVisibility = actionableStatus.getVisibility().toString().toLowerCase();
+        String contentWarning = actionableStatus.spoilerText;
         Status.Mention[] mentions = actionableStatus.mentions;
         List<String> mentionedUsernames = new ArrayList<>();
         for (Status.Mention mention : mentions) {
@@ -76,6 +77,7 @@ public class SFragment extends BaseFragment {
         Intent intent = new Intent(getContext(), ComposeActivity.class);
         intent.putExtra("in_reply_to_id", inReplyToId);
         intent.putExtra("reply_visibility", replyVisibility);
+        intent.putExtra("content_warning", contentWarning);
         intent.putExtra("mentioned_usernames", mentionedUsernames.toArray(new String[0]));
         startActivity(intent);
     }


### PR DESCRIPTION
hi,
Mastodon-Web automatically adds the content-warnings from the toot one is replying to.
I added a few lines that check if a new toot is a reply and if so, it inherits the content notes from its predecessor.