### PR TITLE
Adjust light theme tab bar area

### DIFF
--- a/app/src/main/res/layout/activity_account.xml
+++ b/app/src/main/res/layout/activity_account.xml
@@ -166,6 +166,15 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 
+    <View
+        android:id="@+id/tab_bottom_shadow"
+        android:layout_width="match_parent"
+        android:layout_height="2dp"
+        app:layout_anchor="@id/tab_layout"
+        app:layout_anchorGravity="bottom"
+        android:background="@drawable/material_drawer_shadow_bottom"
+        android:visibility="visible" />
+
     <android.support.design.widget.FloatingActionButton
         android:id="@+id/floating_btn"
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -55,6 +55,7 @@
             </android.support.design.widget.TabLayout>
 
         </android.support.v4.view.ViewPager>
+
     </LinearLayout>
 
     <com.arlib.floatingsearchview.FloatingSearchView
@@ -70,11 +71,15 @@
         app:floatingSearch_leftActionMode="showHamburger"
         app:floatingSearch_close_search_on_keyboard_dismiss="true"/>
 
-    <FrameLayout
-        android:id="@+id/overlay_fragment_container"
+    <View
+        android:id="@+id/tab_bottom_shadow"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
-    </FrameLayout>
+        android:layout_height="2dp"
+        app:layout_anchor="@id/tab_layout"
+        app:layout_anchorGravity="bottom"
+        android:background="@drawable/material_drawer_shadow_bottom"
+        android:visibility="visible" />
+
 
     <android.support.design.widget.FloatingActionButton
         android:id="@+id/floating_btn"
@@ -85,4 +90,9 @@
         android:layout_margin="16dp"
         android:layout_height="wrap_content"
         app:srcCompat="@drawable/ic_create_24dp"/>
+
+    <FrameLayout
+        android:id="@+id/overlay_fragment_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"></FrameLayout>
 </android.support.design.widget.CoordinatorLayout>


### PR DESCRIPTION
Adds a shadow below the TabLayout. This makes it easier to distinguish UI elements as before both the tabs and list below had identical background colors

<img width="394" alt="screen shot 2017-04-09 at 1 59 47 am" src="https://cloud.githubusercontent.com/assets/476133/24836122/687cd220-1cc8-11e7-9bdb-eaf6565e48ba.png">
<img width="401" alt="screen shot 2017-04-09 at 2 00 17 am" src="https://cloud.githubusercontent.com/assets/476133/24836121/687c514c-1cc8-11e7-8cce-af0876b16247.png">
