### PR TITLE
Share menu now allows for sharing of link/actual post

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/SFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/SFragment.java
@@ -182,8 +182,8 @@ public class SFragment extends BaseFragment {
         callList.add(call);
     }
 
-    protected void more(Status status, View view, final AdapterItemRemover adapter,
-            final int position) {
+    protected void more(final Status status, View view, final AdapterItemRemover adapter,
+                        final int position) {
         final String id = status.getActionableId();
         final String accountId = status.getActionableStatus().account.id;
         final String accountUsename = status.getActionableStatus().account.username;
@@ -201,12 +201,25 @@ public class SFragment extends BaseFragment {
                     @Override
                     public boolean onMenuItemClick(MenuItem item) {
                         switch (item.getItemId()) {
-                            case R.id.status_share: {
+                            case R.id.status_share_content: {
+                                StringBuilder sb = new StringBuilder();
+                                sb.append(status.account.username);
+                                sb.append(" - ");
+                                sb.append(status.content.toString());
+
+                                Intent sendIntent = new Intent();
+                                sendIntent.setAction(Intent.ACTION_SEND);
+                                sendIntent.putExtra(Intent.EXTRA_TEXT, sb.toString());
+                                sendIntent.setType("text/plain");
+                                startActivity(Intent.createChooser(sendIntent, getResources().getText(R.string.send_status_content_to)));
+                                return true;
+                            }
+                            case R.id.status_share_link: {
                                 Intent sendIntent = new Intent();
                                 sendIntent.setAction(Intent.ACTION_SEND);
                                 sendIntent.putExtra(Intent.EXTRA_TEXT, statusUrl);
                                 sendIntent.setType("text/plain");
-                                startActivity(Intent.createChooser(sendIntent, getResources().getText(R.string.send_status_to)));
+                                startActivity(Intent.createChooser(sendIntent, getResources().getText(R.string.send_status_link_to)));
                                 return true;
                             }
                             case R.id.status_block: {

--- a/app/src/main/res/menu/status_more.xml
+++ b/app/src/main/res/menu/status_more.xml
@@ -2,7 +2,16 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item
         android:id="@+id/status_share"
-        android:title="@string/action_share"/>
+        android:title="@string/action_share">
+        <menu>
+            <item
+                android:id="@+id/status_share_link"
+                android:title="@string/status_share_link" />
+            <item
+                android:id="@+id/status_share_content"
+                android:title="@string/status_share_content"/>
+        </menu>
+    </item>
     <item android:title="@string/action_block"
         android:id="@+id/status_block" />
     <item android:title="@string/action_report"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -83,7 +83,8 @@
     <string name="toggle_nsfw">NSFW</string>
     <string name="action_compose_options">Options</string>
 
-    <string name="send_status_to">Share toot URL to…</string>
+    <string name="send_status_link_to">Share toot URL to…</string>
+    <string name="send_status_content_to">Share toot to…</string>
 
     <string name="search">Search accounts…</string>
 
@@ -137,5 +138,7 @@
     <string name="notification_title_summary">%d new interactions</string>
 
     <string name="description_account_locked">Locked Account</string>
+    <string name="status_share_content">Share content of toot</string>
+    <string name="status_share_link">Share link to toot</string>
 
 </resources>


### PR DESCRIPTION
changed the share button menu to allow for sharing either the link, or the actual content of the post
added values into @string file to accommodate for the change
added the new share submenu into the status_more layout xml