### PR TITLE
Timeline footer improvements

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/FooterViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/FooterViewHolder.java
@@ -23,6 +23,8 @@ class FooterViewHolder extends RecyclerView.ViewHolder {
     FooterViewHolder(View itemView) {
         super(itemView);
         ProgressBar progressBar = (ProgressBar) itemView.findViewById(R.id.footer_progress_bar);
-        progressBar.setIndeterminate(true);
+        if (progressBar != null) {
+            progressBar.setIndeterminate(true);
+        }
     }
 }

--- a/app/src/main/java/com/keylesspalace/tusky/NotificationsAdapter.java
+++ b/app/src/main/java/com/keylesspalace/tusky/NotificationsAdapter.java
@@ -42,9 +42,16 @@ class NotificationsAdapter extends RecyclerView.Adapter implements AdapterItemRe
     private static final int VIEW_TYPE_STATUS_NOTIFICATION = 2;
     private static final int VIEW_TYPE_FOLLOW = 3;
 
+    enum FooterState {
+        EMPTY,
+        END,
+        LOADING
+    }
+
     private List<Notification> notifications;
     private StatusActionListener statusListener;
     private NotificationActionListener notificationActionListener;
+    private FooterState footerState = FooterState.END;
 
     NotificationsAdapter(StatusActionListener statusListener,
             NotificationActionListener notificationActionListener) {
@@ -52,6 +59,15 @@ class NotificationsAdapter extends RecyclerView.Adapter implements AdapterItemRe
         notifications = new ArrayList<>();
         this.statusListener = statusListener;
         this.notificationActionListener = notificationActionListener;
+    }
+
+
+    public void setFooterState(FooterState newFooterState) {
+        FooterState oldValue = footerState;
+        footerState = newFooterState;
+        if (footerState != oldValue) {
+            notifyItemChanged(notifications.size());
+        }
     }
 
     @Override
@@ -64,8 +80,24 @@ class NotificationsAdapter extends RecyclerView.Adapter implements AdapterItemRe
                 return new StatusViewHolder(view);
             }
             case VIEW_TYPE_FOOTER: {
-                View view = LayoutInflater.from(parent.getContext())
-                        .inflate(R.layout.item_footer, parent, false);
+                View view;
+                switch (footerState) {
+                    default:
+                    case LOADING:
+                        view = LayoutInflater.from(parent.getContext())
+                                .inflate(R.layout.item_footer, parent, false);
+                        break;
+                    case END: {
+                        view = LayoutInflater.from(parent.getContext())
+                                .inflate(R.layout.item_footer_end, parent, false);
+                        break;
+                    }
+                    case EMPTY: {
+                        view = LayoutInflater.from(parent.getContext())
+                                .inflate(R.layout.item_footer_empty, parent, false);
+                        break;
+                    }
+                }
                 return new FooterViewHolder(view);
             }
             case VIEW_TYPE_STATUS_NOTIFICATION: {

--- a/app/src/main/java/com/keylesspalace/tusky/NotificationsFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/NotificationsFragment.java
@@ -144,6 +144,10 @@ public class NotificationsFragment extends SFragment implements
     private void sendFetchNotificationsRequest(final String fromId, String uptoId) {
         MastodonAPI api = ((BaseActivity) getActivity()).mastodonAPI;
 
+        if (fromId != null || adapter.getItemCount() <= 1) {
+            adapter.setFooterState(NotificationsAdapter.FooterState.LOADING);
+        }
+
         listCall = api.notifications(fromId, uptoId, null);
 
         listCall.enqueue(new Callback<List<Notification>>() {
@@ -191,6 +195,11 @@ public class NotificationsFragment extends SFragment implements
             }
         } else {
             adapter.update(notifications);
+        }
+        if (notifications.size() == 0 && adapter.getItemCount() == 1) {
+            adapter.setFooterState(NotificationsAdapter.FooterState.EMPTY);
+        } else if (fromId != null) {
+            adapter.setFooterState(NotificationsAdapter.FooterState.END);
         }
         swipeRefreshLayout.setRefreshing(false);
     }

--- a/app/src/main/java/com/keylesspalace/tusky/TimelineAdapter.java
+++ b/app/src/main/java/com/keylesspalace/tusky/TimelineAdapter.java
@@ -30,8 +30,15 @@ class TimelineAdapter extends RecyclerView.Adapter implements AdapterItemRemover
     private static final int VIEW_TYPE_STATUS = 0;
     private static final int VIEW_TYPE_FOOTER = 1;
 
+    enum FooterState {
+        EMPTY,
+        END,
+        LOADING
+    }
+
     private List<Status> statuses;
     private StatusActionListener statusListener;
+    private FooterState footerState = FooterState.END;
 
     TimelineAdapter(StatusActionListener statusListener) {
         super();
@@ -49,10 +56,34 @@ class TimelineAdapter extends RecyclerView.Adapter implements AdapterItemRemover
                 return new StatusViewHolder(view);
             }
             case VIEW_TYPE_FOOTER: {
-                View view = LayoutInflater.from(viewGroup.getContext())
-                        .inflate(R.layout.item_footer, viewGroup, false);
+                View view;
+                switch (footerState) {
+                    default:
+                    case LOADING:
+                        view = LayoutInflater.from(viewGroup.getContext())
+                                .inflate(R.layout.item_footer, viewGroup, false);
+                        break;
+                    case END: {
+                        view = LayoutInflater.from(viewGroup.getContext())
+                                .inflate(R.layout.item_footer_end, viewGroup, false);
+                        break;
+                    }
+                    case EMPTY: {
+                        view = LayoutInflater.from(viewGroup.getContext())
+                                .inflate(R.layout.item_footer_empty, viewGroup, false);
+                        break;
+                    }
+                }
                 return new FooterViewHolder(view);
             }
+        }
+    }
+
+    public void setFooterState(FooterState newFooterState) {
+        FooterState oldValue = footerState;
+        footerState = newFooterState;
+        if (footerState != oldValue) {
+            notifyItemChanged(statuses.size());
         }
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/TimelineFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/TimelineFragment.java
@@ -214,6 +214,10 @@ public class TimelineFragment extends SFragment implements
     private void sendFetchTimelineRequest(@Nullable final String fromId, @Nullable String uptoId) {
         MastodonAPI api = ((BaseActivity) getActivity()).mastodonAPI;
 
+        if (fromId != null || adapter.getItemCount() <= 1) {
+            adapter.setFooterState(TimelineAdapter.FooterState.LOADING);
+        }
+
         Callback<List<Status>> cb = new Callback<List<Status>>() {
             @Override
             public void onResponse(Call<List<Status>> call, retrofit2.Response<List<Status>> response) {
@@ -281,6 +285,11 @@ public class TimelineFragment extends SFragment implements
             }
         } else {
             adapter.update(statuses);
+        }
+        if (statuses.size() == 0 && adapter.getItemCount() == 1) {
+            adapter.setFooterState(TimelineAdapter.FooterState.EMPTY);
+        } else if(fromId != null) {
+            adapter.setFooterState(TimelineAdapter.FooterState.END);
         }
         swipeRefreshLayout.setRefreshing(false);
     }

--- a/app/src/main/res/layout/item_footer_empty.xml
+++ b/app/src/main/res/layout/item_footer_empty.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+xmlns:android="http://schemas.android.com/apk/res/android"
+xmlns:app="http://schemas.android.com/apk/res-auto"
+android:layout_width="match_parent"
+android:layout_height="match_parent"
+android:padding="16dp"
+android:gravity="center"
+android:orientation="vertical">
+
+<ImageView
+    android:id="@+id/imageView"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    app:srcCompat="@drawable/elephant_friend" />
+
+<TextView
+    android:id="@+id/textView"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="16dp"
+    android:text="@string/footer_empty"
+    android:textAlignment="center" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_footer_end.xml
+++ b/app/src/main/res/layout/item_footer_end.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:orientation="vertical">
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,6 +38,7 @@
     <string name="footer_end_of_statuses">end of the statuses</string>
     <string name="footer_end_of_notifications">end of the notifications</string>
     <string name="footer_end_of_accounts">end of the accounts</string>
+    <string name="footer_empty">There are no toots here so far. Pull down to refresh!</string>
 
     <string name="notification_reblog_format">%s boosted your toot</string>
     <string name="notification_favourite_format">%s favourited your toot</string>


### PR DESCRIPTION
The current implementation of endless scrolling has a few user interface issues, for example that the loading animation is shown even if nothing is loaded in the background (see eg. #62).

This pull request is not perfect in all situations, but improves the overall situation, especially for new users.

Before:
<img src="https://cloud.githubusercontent.com/assets/64280/25065508/9f21f348-2211-11e7-8591-456557a392f8.png" width="300"> <img src="https://cloud.githubusercontent.com/assets/64280/25065507/9f20f416-2211-11e7-92a8-d605213ab9a2.png" width="300">

After:
<img src="https://cloud.githubusercontent.com/assets/64280/25065505/9f1c4ad8-2211-11e7-8f1a-edc843d6ee55.png" width="300"> <img src="https://cloud.githubusercontent.com/assets/64280/25065506/9f1fbc86-2211-11e7-8746-f3c54b64b78c.png" width="300">