### PR TITLE
Improves Japanese translation

### DIFF
--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,20 +1,21 @@
 <resources>
 
     <string name="error_generic">エラーが発生しました。</string>
-    <string name="error_invalid_domain">不正なドメイン名が入力されました</string>
-    <string name="error_failed_app_registration">そのインスタンスでの認証が失敗しました</string>
-    <string name="error_no_web_browser_found">使用するブラウザを見つけることができません。</string>
-    <string name="error_authorization_unknown">未定義の認証エラーが発生しました。</string>
-    <string name="error_authorization_denied">認証は拒否されました。</string>
+    <string name="error_empty">本文なしでは投稿できません。</string>
+    <string name="error_invalid_domain">無効なドメインです</string>
+    <string name="error_failed_app_registration">そのインスタンスでの認証に失敗しました。</string>
+    <string name="error_no_web_browser_found">ウェブブラウザが見つかりませんでした。</string>
+    <string name="error_authorization_unknown">不明な承認エラーが発生しました。</string>
+    <string name="error_authorization_denied">承認が拒否されました。</string>
     <string name="error_retrieving_oauth_token">ログイントークンの取得に失敗しました。</string>
-    <string name="error_compose_character_limit">ステータスが非常に長い！</string>
+    <string name="error_compose_character_limit">投稿文が長すぎます！</string>
     <string name="error_media_upload_size">ファイルは4MB未満にしてください。</string>
-    <string name="error_media_upload_type">このファイル種別はアップロードできません。</string>
-    <string name="error_media_upload_opening">このファイルは開けません。</string>
-    <string name="error_media_upload_permission">メディアの読み込み権限が必要です。</string>
-    <string name="error_media_upload_image_or_video">同一のステータスに画像とビデオを一緒にすることはできません。</string>
+    <string name="error_media_upload_type">その形式のファイルはアップロードできません。</string>
+    <string name="error_media_upload_opening">ファイルを開けませんでした。</string>
+    <string name="error_media_upload_permission">メディアの読み取り許可が必要です。</string>
+    <string name="error_media_upload_image_or_video">画像と動画を同時に投稿することはできません。</string>
     <string name="error_media_upload_sending">アップロードに失敗しました。</string>
-    <string name="error_report_too_few_statuses">少なくとも1つのステータスを報告してください。</string>
+    <string name="error_report_too_few_statuses">少なくとも1つの投稿を報告してください。</string>
 
     <string name="title_home">ホーム</string>
     <string name="title_notifications">通知</string>
@@ -29,114 +30,119 @@
     <string name="title_blocks">ブロックしたユーザー</string>
 
     <string name="status_username_format">\@%s</string>
-    <string name="status_boosted_format">%s 加速されました</string>
-    <string name="status_sensitive_media_title">不適切なメディア</string>
+    <string name="status_boosted_format">%sさんがブーストしました</string>
+    <string name="status_sensitive_media_title">不適切なコンテンツ</string>
     <string name="status_sensitive_media_directions">タップして表示</string>
-    <string name="status_content_warning_show_more">さらに表示</string>
-    <string name="status_content_warning_show_less">省略表示</string>
+    <string name="status_content_warning_show_more">続きを表示</string>
+    <string name="status_content_warning_show_less">続きを隠す</string>
 
-    <string name="footer_end_of_statuses">これ以降にステータスはありません</string>
+    <string name="footer_end_of_statuses">これ以降に投稿はありません</string>
     <string name="footer_end_of_notifications">これ以降に通知はありません</string>
     <string name="footer_end_of_accounts">これ以降にアカウントはありません</string>
+    <string name="footer_empty">現在トゥートはありません。更新するにはプルダウンしてください！</string>
 
-    <string name="notification_reblog_format">%s があたなのトゥートをブーストしました</string>
-    <string name="notification_favourite_format">%s があなたのトゥートをお気に入りに追加しました</string>
-    <string name="notification_follow_format">%s があなたをフォローしました</string>
+    <string name="notification_reblog_format">%sさんがトゥートをブーストしました</string>
+    <string name="notification_favourite_format">%sさんがトゥートをお気に入りに登録しました</string>
+    <string name="notification_follow_format">%sさんにフォローされました</string>
 
-    <string name="report_username_format">\@%s を通報</string>
-    <string name="report_comment_hint">コメントを追加しますか？</string>
+    <string name="report_username_format">\@%sさんを通報</string>
+    <string name="report_comment_hint">コメント</string>
 
     <string name="action_reply">返信</string>
     <string name="action_reblog">ブースト</string>
     <string name="action_favourite">お気に入り</string>
-    <string name="action_more">もっと読む</string>
-    <string name="action_compose">作成</string>
-    <string name="action_login">Mastodonにログイン</string>
+    <string name="action_more">その他</string>
+    <string name="action_compose">新規投稿</string>
+    <string name="action_login">Mastodonでログイン</string>
     <string name="action_logout">ログアウト</string>
-    <string name="action_follow">フォロー</string>
+    <string name="action_follow">フォローする</string>
     <string name="action_unfollow">フォロー解除</string>
     <string name="action_block">ブロック</string>
     <string name="action_unblock">ブロック解除</string>
-    <string name="action_report">報告</string>
+    <string name="action_report">通報</string>
     <string name="action_delete">削除</string>
     <string name="action_send">トゥート</string>
     <string name="action_send_public">トゥート！</string>
-    <string name="action_retry">リトライ</string>
-    <string name="action_mark_sensitive">不適切なメディアとする</string>
-    <string name="action_hide_text">警告のあるテキストを隠す</string>
-    <string name="action_ok">Ok</string>
+    <string name="action_retry">再試行</string>
+    <string name="action_mark_sensitive">不適切なコンテンツとして設定</string>
+    <string name="action_hide_text">投稿文を注意書きで隠す</string>
+    <string name="action_ok">OK</string>
     <string name="action_cancel">キャンセル</string>
     <string name="action_close">閉じる</string>
     <string name="action_back">戻る</string>
-    <string name="action_view_profile">プロファイル</string>
+    <string name="action_view_profile">プロフィール</string>
     <string name="action_view_preferences">設定</string>
     <string name="action_view_favourites">お気に入り</string>
     <string name="action_view_blocks">ブロックしたユーザー</string>
     <string name="action_view_thread">スレッド</string>
     <string name="action_view_media">メディア</string>
     <string name="action_open_in_web">ブラウザで開く</string>
-    <string name="action_submit">投稿</string>
+    <string name="action_submit">決定</string>
     <string name="action_photo_pick">メディアを追加</string>
     <string name="action_share">共有</string>
     <string name="action_mute">ミュート</string>
     <string name="action_unmute">ミュート解除</string>
-    <string name="action_mention">メンション</string>
+    <string name="action_mention">返信</string>
     <string name="toggle_nsfw">NSFW</string>
     <string name="action_compose_options">オプション</string>
-    <string name="action_open_drawer">ドローワを開く</string>
-    <string name="action_clear">クリア</string>
+    <string name="action_open_drawer">メニューを開く</string>
+    <string name="action_clear">消去</string>
 
-    <string name="send_status_to">トゥートURLを共通…</string>
+    <string name="send_status_link_to">トゥートのURLを共有…</string>
+    <string name="send_status_content_to">トゥートを共有…</string>
 
-    <string name="search">アカウントを検索…</string>
+    <string name="search">ユーザーを検索…</string>
 
     <string name="confirmation_send">トゥート！</string>
     <string name="confirmation_reported">送信しました！</string>
 
     <string name="hint_domain">どのインスタンス？</string>
-    <string name="hint_compose">今何してる？</string>
-    <string name="hint_content_warning">コンテンツの警告</string>
+    <string name="hint_compose">今なにしてる？</string>
+    <string name="hint_content_warning">注意書き</string>
 
-    <string name="link_whats_an_instance">インスタンスって？</string>
+    <string name="link_whats_an_instance">インスタンスとは？</string>
 
-    <string name="dialog_whats_an_instance">インスタンスのアドレスもしくはドメインをここに入力してください。
-        例えば mastodon.social, mstdn.jp, pawoo.net, や
-        <a href="https://github.com/tootsuite/mastodon/blob/master/docs/Using-Mastodon/List-of-Mastodon-instances.md">などです！</a>
-        \n\nもしアカウントを持っていない場合は、参加したいインスタンスの名前を入力してください。\n\n
-        インスタンスはあなたのアカウントを単一の場所で管理(ホスト)しますが、ほかのインスタンスと同じサイトであるかのように人をフォローしたり連絡することができます。
-        \n\n詳しくは<a href="https://mastodon.social/about">mastodon.social</a>を見てください。
+    <string name="dialog_whats_an_instance">mastodon.social, mstdn.jp, pawoo.net や
+        <a href="https://github.com/tootsuite/documentation/blob/master/Using-Mastodon/List-of-Mastodon-instances.md">その他</a>
+        のような、あらゆるインスタンスのアドレスやドメインを入力できます。
+        \n\nまだアカウントをお持ちでない場合は、参加したいインスタンスの名前を入力することで
+        そのインスタンスにアカウントを作成できます。\n\nインスタンスはあなたのアカウントが提供される単独の場所ですが、
+        他のインスタンスのユーザーとあたかも同じ場所にいるように簡単にコミュニケーションをとったりフォローしたりできます。
+        \n\nさらに詳しい情報は<a href="https://mastodon.social/about">mastodon.social</a>でご覧いただけます。
     </string>
-    <string name="dialog_title_finishing_media_upload">メディアのアップロードが完了</string>
+    <string name="dialog_title_finishing_media_upload">メディアをアップロードしています</string>
     <string name="dialog_message_uploading_media">アップロード中…</string>
 
-    <string name="visibility_public">すべての人が表示可能</string>
-    <string name="visibility_unlisted">すべての人が表示可能だが公開タイムラインには載せない</string>
-    <string name="visibility_private">フォロワーとメンションのみ表示可能</string>
+    <string name="visibility_public">全体へ公開</string>
+    <string name="visibility_unlisted">全体へ公開するが、公開タイムラインには表示しない</string>
+    <string name="visibility_private">フォロワーと返信先にのみに表示</string>
 
     <string name="pref_title_notification_settings">通知</string>
-    <string name="pref_title_edit_notification_settings">通知を編集</string>
+    <string name="pref_title_edit_notification_settings">通知を設定</string>
     <string name="pref_title_notifications_enabled">プッシュ通知</string>
-    <string name="pref_title_notification_alerts">アラート</string>
-    <string name="pref_title_notification_alert_sound">音で通知</string>
-    <string name="pref_title_notification_alert_vibrate">バイブレーションで通知</string>
-    <string name="pref_title_notification_alert_light">ライトで通知</string>
-    <string name="pref_title_notification_filters">通知する状態</string>
-    <string name="pref_title_notification_filter_mentions">メンションがありました</string>
-    <string name="pref_title_notification_filter_follows">フォローされた</string>
-    <string name="pref_title_notification_filter_reblogs">私の投稿がブーストされました</string>
-    <string name="pref_title_notification_filter_favourites">私の投稿がお気に入りに追加されました</string>
+    <string name="pref_title_notification_alerts">通知時の動作</string>
+    <string name="pref_title_notification_alert_sound">着信音を鳴らす</string>
+    <string name="pref_title_notification_alert_vibrate">バイブレーションする</string>
+    <string name="pref_title_notification_alert_light">通知ランプ</string>
+    <string name="pref_title_notification_filters">通知の種類</string>
+    <string name="pref_title_notification_filter_mentions">返信</string>
+    <string name="pref_title_notification_filter_follows">フォロー</string>
+    <string name="pref_title_notification_filter_reblogs">投稿がブーストされた</string>
+    <string name="pref_title_notification_filter_favourites">投稿がお気に入りに登録された</string>
     <string name="pref_title_appearance_settings">表示</string>
     <string name="pref_title_light_theme">明るいテーマを使用</string>
     <string name="pref_title_browser_settings">ブラウザ</string>
-    <string name="pref_title_custom_tabs">Chromeカスタムタブを使用</string>
-    <string name="pref_title_hide_follow_button">スクロール中にフォローボタンを非表示</string>
+    <string name="pref_title_custom_tabs">Chrome Custom Tabsを使用する</string>
+    <string name="pref_title_hide_follow_button">スクロール中はフォローボタンを隠す</string>
 
-    <string name="notification_mention_format">%s があなたにメンションを送信しました</string>
-    <string name="notification_summary_large">%1$s、%2$s、%3$s と他に%4$d件</string>
-    <string name="notification_summary_medium">%1$s、%2$s、と %3$s</string>
-    <string name="notification_summary_small">%1$s と %2$s</string>
-    <string name="notification_title_summary">%d 新しいお知らせ</string>
+    <string name="notification_mention_format">%sさんが返信しました</string>
+    <string name="notification_summary_large">%1$sさん、%2$sさん、%3$sさんと他%4$d人</string>
+    <string name="notification_summary_medium">%1$sさん、%2$sさん、%3$sさん</string>
+    <string name="notification_summary_small">%1$sさん、%2$sさん</string>
+    <string name="notification_title_summary">%d件の新しい通知</string>
 
-    <string name="description_account_locked">ロックされたアカウント</string>
+    <string name="description_account_locked">非公開アカウント</string>
+    <string name="status_share_content">トゥートの内容を共有</string>
+    <string name="status_share_link">トゥートへのリンクを共有</string>
 
 </resources>


### PR DESCRIPTION
Improved and added new translation.

In string name="dialog_whats_an_instance", fixed link of List-of-Mastodon-instances.md from [old URL](https://github.com/tootsuite/mastodon/blob/master/docs/Using-Mastodon/List-of-Mastodon-instances.md) to [new URL](https://github.com/tootsuite/documentation/blob/master/Using-Mastodon/List-of-Mastodon-instances.md) that has moved.