### PR TITLE
Make compose EditText TYPE_TEXT_FLAG_CAP_SENTENCES

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/ComposeActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/ComposeActivity.java
@@ -744,7 +744,7 @@ public class  ComposeActivity extends BaseActivity implements ComposeOptionsFrag
         ViewGroup.LayoutParams layoutParams = new ViewGroup.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT);
         editText.setLayoutParams(layoutParams);
-        editText.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_MULTI_LINE);
+        editText.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_MULTI_LINE | InputType.TYPE_TEXT_FLAG_CAP_SENTENCES);
         editText.setEms(10);
         editText.setBackgroundColor(0);
         editText.setGravity(Gravity.START | Gravity.TOP);


### PR DESCRIPTION
When entering text in the compose field default to capitalizing the first letter of the sentence. Eg instead of `foo` have it be `Foo` 

(uses [TYPE_TEXT_FLAG_CAP_SENTENCES](https://developer.android.com/reference/android/text/InputType.html#TYPE_TEXT_FLAG_CAP_SENTENCES))