### PR TITLE
Normalize strings

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1,14 +1,24 @@
 <resources>
 
     <string name="error_generic">وقع هناك خطأ.</string>
+    <!-- <string name="error_empty">This cannot be empty.</string> -->
     <string name="error_invalid_domain">اسم النطاق غير صالح</string>
     <string name="error_failed_app_registration">اخفقت المصادقة مع مثيل الخادم هذا.</string>
     <string name="error_no_web_browser_found">لم يتم العثور على متصفح قابل للإستعمال.</string>
+    <!-- <string name="error_authorization_unknown">An unidentified authorization error occurred.</string> -->
     <string name="error_authorization_denied">تم رفض التصريح.</string>
+    <!-- <string name="error_retrieving_oauth_token">Failed getting a login token.</string> -->
+    <!-- <string name="error_compose_character_limit">The status is too long!</string> -->
     <string name="error_media_upload_size">يجب أن يكون حجم الملف أقل من 4 ميغابايت.</string>
     <string name="error_media_upload_type">لا يمكن رفع هذا النوع من الملفات.</string>
     <string name="error_media_upload_opening">تعذر فتح ذاك الملف.</string>
+    <!-- <string name="error_media_upload_permission">Permission to read media is required.</string> -->
+    <!-- <string name="error_media_download_permission">Permission to store media is required.</string> -->
+
+    <!-- <string name="error_media_upload_image_or_video">Images and videos cannot both be attached to the same status.</string> -->
     <string name="error_media_upload_sending">اخفقت عملية الرفع.</string>
+    <!-- <string name="error_report_too_few_statuses">At least one status must be reported.</string> -->
+
     <string name="title_home">الرئيسية</string>
     <string name="title_notifications">الاشعارات</string>
     <string name="title_public_local">المحلية</string>
@@ -31,6 +41,7 @@
     <string name="footer_end_of_statuses">نهاية الحالات</string>
     <string name="footer_end_of_notifications">نهاية الاشعارات</string>
     <string name="footer_end_of_accounts">نهاية الحسابات</string>
+    <!-- <string name="footer_empty">There are no toots here so far. Pull down to refresh!</string> -->
 
     <string name="notification_reblog_format">%s عزز تبويقك</string>
     <string name="notification_favourite_format">%s أعجب بتبويقك</string>
@@ -55,6 +66,7 @@
     <string name="action_send">تبويق</string>
     <string name="action_send_public">بَوِّق</string>
     <string name="action_retry">إعادة المحاولة</string>
+    <!-- <string name="action_mark_sensitive">Mark media sensitive</string> -->
     <string name="action_hide_text">اخفي النص وراء تحذير</string>
     <string name="action_ok">موافق</string>
     <string name="action_cancel">إلغاء</string>
@@ -69,6 +81,7 @@
     <string name="action_open_in_web">إفتح في متصفح</string>
     <string name="action_submit">ارسل</string>
     <string name="action_photo_pick">إضافة وسائط</string>
+    <!-- <string name="action_photo_take">Take photo</string> -->
     <string name="action_share">شارك</string>
     <string name="action_mute">أكتم</string>
     <string name="action_unmute">إلغاء الكتم</string>
@@ -77,8 +90,11 @@
     <string name="action_compose_options">خيارات</string>
     <string name="action_open_drawer">إفتح الدرج</string>
     <string name="action_clear">إمسح</string>
+    <!-- <string name="action_save">Save</string> -->
+    <!-- <string name="action_edit_profile">Edit profile</string> -->
 
-    <string name="send_status_to">شارك رابط التبويق إلى ...</string>
+    <string name="send_status_link_to">شارك رابط التبويق إلى ...</string>
+    <!-- <string name="send_status_content_to">Share toot to…</string> -->
 
     <string name="search">ابحث عن حسابات ...</string>
 
@@ -88,11 +104,31 @@
     <string name="hint_domain">أي سيرفر ؟</string>
     <string name="hint_compose">ما الجديد ؟</string>
     <string name="hint_content_warning">تحذير عن المحتوى</string>
+    <!-- <string name="hint_display_name">Display name</string> -->
+    <!-- <string name="hint_note">Bio</string> -->
+
+    <!-- <string name="label_avatar">Avatar</string> -->
+    <!-- <string name="label_header">Header</string> -->
 
     <string name="link_whats_an_instance">ماذا نعني بمثيل الخادم ؟</string>
 
+    <!-- <string name="dialog_whats_an_instance">The address or domain of any instance can be entered -->
+    <!--     here, such as mastodon.social, icosahedron.website, social.tchncs.de, and -->
+    <!--     <a href="https://github.com/tootsuite/mastodon/blob/master/docs/Using-Mastodon/List-of-Mastodon-instances.md">more!</a> -->
+    <!--     \n\nIf you don\'t yet have an account, you can enter the name of the instance you\'d like to -->
+    <!--     join and create an account there.\n\nAn instance is a single place where your account is -->
+    <!--     hosted, but you can easily communicate with and follow folks on other instances as though -->
+    <!--     you were on the same site. -->
+    <!--     \n\nMore info can be found at <a href="https://mastodon.social/about">mastodon.social</a>. -->
+    <!-- </string> -->
     <string name="dialog_title_finishing_media_upload">تتمة رفع الوسائط</string>
     <string name="dialog_message_uploading_media">جاري الرفع ...</string>
+    <!-- <string name="dialog_download_image">Download</string> -->
+
+    <!-- <string name="visibility_public">Public: Post to public timelines</string> -->
+    <!-- <string name="visibility_unlisted">Unlisted: Do not show in public timelines</string> -->
+    <!-- <string name="visibility_private">Private: Post to followers only</string> -->
+    <!-- <string name="visibility_direct">Direct: Post to mentioned users only</string> -->
 
     <string name="pref_title_notification_settings">الاشعارات</string>
     <string name="pref_title_edit_notification_settings">تعديل الاشعارات</string>
@@ -110,6 +146,8 @@
     <string name="pref_title_light_theme">إستخدم سمةً فاتحة اللون</string>
     <string name="pref_title_browser_settings">المتصفح</string>
     <string name="pref_title_custom_tabs">إخفاء زر المتابعة أثناء تمرير الصفحة</string>
+    <!-- <string name="pref_title_hide_follow_button">Hide follow button while scrolling</string> -->
+
     <string name="notification_mention_format">%s أشار إليك</string>
     <string name="notification_summary_large">%1$s, %2$s, %3$s و %4$d أخرى</string>
     <string name="notification_summary_medium">%1$s, %2$s, و %3$s</string>
@@ -117,5 +155,6 @@
     <string name="notification_title_summary">%d تفاعلات جديدة</string>
 
     <string name="description_account_locked">حساب مقفل</string>
-
+    <!-- <string name="status_share_content">Share content of toot</string> -->
+    <!-- <string name="status_share_link">Share link to toot</string> -->
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,20 +1,23 @@
 <resources>
+
+    <string name="error_generic">Ein Fehler ist aufgetreten.</string>
+    <!-- <string name="error_empty">This cannot be empty.</string> -->
     <string name="error_invalid_domain">Ungültige Domain angegeben</string>
     <string name="error_failed_app_registration">Diese App konnte sich auf dem Server nicht authentifizieren.</string>
+    <string name="error_no_web_browser_found">Kein Webbrowser gefunden.</string>
     <string name="error_authorization_unknown">Ein undefinierbarer Autorisierungsfehler ist aufgetreten.</string>
+    <string name="error_authorization_denied">Autorisierung fehlgeschlagen.</string>
+    <string name="error_retrieving_oauth_token">Es konnte kein Login-Token abgerufen werden.</string>
     <string name="error_compose_character_limit">Der Beitrag ist zu lang!</string>
     <string name="error_media_upload_size">Die Datei muss kleiner als 4MB sein.</string>
     <string name="error_media_upload_type">Dieser Dateityp darf nicht hochgeladen werden.</string>
     <string name="error_media_upload_opening">Die Datei konnte nicht geöffnet werden.</string>
     <string name="error_media_upload_permission">Eine Leseberechtigung wird für das Hochladen der Mediendatei benötigt.</string>
+    <string name="error_media_download_permission">Eine Berechtigung wird zum Speichern des Mediums benötigt.</string>
+
     <string name="error_media_upload_image_or_video">Bilder und Videos können beide nicht an den Beitrag angehängt werden.</string>
     <string name="error_media_upload_sending">Die Mediendatei konnte nicht hochgeladen werden.</string>
     <string name="error_report_too_few_statuses">Mindestens ein Beitrag muss berichtet werden.</string>
-    <string name="error_authorization_denied">Autorisierung fehlgeschlagen.</string>
-    <string name="error_generic">Ein Fehler ist aufgetreten.</string>
-    <string name="error_no_web_browser_found">Kein Webbrowser gefunden.</string>
-    <string name="error_retrieving_oauth_token">Es konnte kein Login-Token abgerufen werden.</string>
-    <string name="error_media_download_permission">Eine Berechtigung wird zum Speichern des Mediums benötigt.</string>
 
     <string name="title_home">Start</string>
     <string name="title_notifications">Benachrichtigungen</string>
@@ -38,6 +41,7 @@
     <string name="footer_end_of_statuses">Ende des Beitrages</string>
     <string name="footer_end_of_notifications">Ende der Benachrichtigungen</string>
     <string name="footer_end_of_accounts">Ende der Accounts</string>
+    <!-- <string name="footer_empty">There are no toots here so far. Pull down to refresh!</string> -->
 
     <string name="notification_reblog_format">%s teilte deinen Beitrag</string>
     <string name="notification_favourite_format">%s favorisierte deinen Beitrag</string>
@@ -46,6 +50,10 @@
     <string name="report_username_format">\@%s melden</string>
     <string name="report_comment_hint">Irgendwelche Anmerkungen?</string>
 
+    <string name="action_reply">Antworten</string>
+    <string name="action_reblog">Teilen</string>
+    <string name="action_favourite">Favorisieren</string>
+    <string name="action_more">Mehr</string>
     <string name="action_compose">Schreiben</string>
     <string name="action_login">Anmelden mit Mastodon</string>
     <string name="action_logout">Ausloggen</string>
@@ -68,26 +76,25 @@
     <string name="action_view_preferences">Einstellungen</string>
     <string name="action_view_favourites">Favoriten</string>
     <string name="action_view_blocks">Blockierte Nutzer</string>
+    <string name="action_view_thread">Thread</string>
+    <string name="action_view_media">Medien</string>
     <string name="action_open_in_web">Im Browser öffnen</string>
     <string name="action_submit">Senden</string>
     <string name="action_photo_pick">Füge Medien hinzu</string>
+    <!-- <string name="action_photo_take">Take photo</string> -->
     <string name="action_share">Teilen</string>
     <string name="action_mute">Stummschalten</string>
     <string name="action_unmute">Lautschalten</string>
     <string name="action_mention">Erwähnen</string>
-    <string name="action_reply">Antworten</string>
-    <string name="action_reblog">Teilen</string>
-    <string name="action_favourite">Favorisieren</string>
-    <string name="action_more">Mehr</string>
-    <string name="action_view_thread">Thread</string>
-    <string name="action_view_media">Medien</string>
+    <string name="toggle_nsfw">NSFW</string>
     <string name="action_compose_options">Einstellungen</string>
     <string name="action_open_drawer">Drawer öffnen</string>
     <string name="action_clear">Löschen</string>
+    <!-- <string name="action_save">Save</string> -->
+    <!-- <string name="action_edit_profile">Edit profile</string> -->
 
-    <string name="toggle_nsfw">NSFW</string>
-
-    <string name="send_status_to">Teile Toot-URL zu…</string>
+    <string name="send_status_link_to">Teile Toot-URL zu…</string>
+    <!-- <string name="send_status_content_to">Share toot to…</string> -->
 
     <string name="search">Suche Accounts…</string>
 
@@ -97,6 +104,11 @@
     <string name="hint_domain">Welche Instanz?</string>
     <string name="hint_compose">Was passiert gerade?</string>
     <string name="hint_content_warning">Inhaltswarnung</string>
+    <!-- <string name="hint_display_name">Display name</string> -->
+    <!-- <string name="hint_note">Bio</string> -->
+
+    <!-- <string name="label_avatar">Avatar</string> -->
+    <!-- <string name="label_header">Header</string> -->
 
     <string name="link_whats_an_instance">Was ist eine Instanz?</string>
 
@@ -113,23 +125,22 @@
     <string name="visibility_public">Öffentlich sichtbar</string>
     <string name="visibility_unlisted">Öffentlich sichtbar, aber nicht in der öffentlichen Timeline</string>
     <string name="visibility_private">Nur für Follower und Erwähnte sichtbar</string>
+    <!-- <string name="visibility_direct">Direct: Post to mentioned users only</string> -->
 
     <string name="pref_title_notification_settings">Benachrichtigungen</string>
+    <string name="pref_title_edit_notification_settings">Benachrichtigungseinstellungen</string>
     <string name="pref_title_notifications_enabled">Push-Benachrichtigungen</string>
+    <string name="pref_title_notification_alerts">Benachrichtigungen</string>
     <string name="pref_title_notification_alert_sound">Benachrichtige mit Sound</string>
     <string name="pref_title_notification_alert_vibrate">Benachrichtige mit Vibration</string>
     <string name="pref_title_notification_alert_light">Benachrichtige mit Licht</string>
+    <string name="pref_title_notification_filters">Benachrichtigen wenn</string>
+    <string name="pref_title_notification_filter_mentions">Ich erwähnt werde</string>
+    <string name="pref_title_notification_filter_follows">Mir jemand folgt</string>
+    <string name="pref_title_notification_filter_reblogs">Jemand meine Posts teilt</string>
+    <string name="pref_title_notification_filter_favourites">Jemandem meine Posts gefallen</string>
     <string name="pref_title_appearance_settings">Aussehen</string>
     <string name="pref_title_light_theme">Benutze helles Theme</string>
-
-    <string name="pref_title_notification_alerts">Benachrichtigungen</string>
-    <string name="pref_title_edit_notification_settings">Benachrichtigungseinstellungen</string>
-    <string name="pref_title_notification_filter_favourites">Jemandem meine Posts gefallen</string>
-    <string name="pref_title_notification_filters">Benachrichtigen wenn</string>
-    <string name="pref_title_notification_filter_follows">Mir jemand folgt</string>
-    <string name="pref_title_notification_filter_mentions">Ich erwähnt werde</string>
-
-    <string name="pref_title_notification_filter_reblogs">Jemand meine Posts teilt</string>
     <string name="pref_title_browser_settings">Browser</string>
     <string name="pref_title_custom_tabs">Öffne Links in der App</string>
     <string name="pref_title_hide_follow_button">Verstecke Button bei Bildlauf </string>
@@ -141,5 +152,6 @@
     <string name="notification_title_summary">%d neue Interaktionen</string>
 
     <string name="description_account_locked">Gesperrter Account</string>
-
+    <!-- <string name="status_share_content">Share content of toot</string> -->
+    <!-- <string name="status_share_link">Share link to toot</string> -->
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <string name="error_generic">Une erreur s’est produite.</string>
-    <string name="error_empty">This cannot be empty.</string>
+    <string name="error_empty">Ce champs ne peut pas être vide</string>
     <string name="error_invalid_domain">Le domaine est invalide</string>
     <string name="error_failed_app_registration">L’application n’a pu s’authentifier avec l’instance.</string>
     <string name="error_no_web_browser_found">Impossible de trouver un navigateur web.</string>
@@ -13,7 +13,7 @@
     <string name="error_media_upload_type">Ce type de fichier n’est pas accepté.</string>
     <string name="error_media_upload_opening">Le fichier ne peut être ouvert.</string>
     <string name="error_media_upload_permission">Une permission pour lire ce média est requise pour le mettre en ligne.</string>
-    <string name="error_media_download_permission">Permission to store media is required.</string>
+    <string name="error_media_download_permission">Permission d\'enregistrer le fichier requise.</string>
 
     <string name="error_media_upload_image_or_video">Impossible de mettre une vidéo et une image sur le même pouet.</string>
     <string name="error_media_upload_sending">Ce média ne peut être mis en ligne.</string>
@@ -41,7 +41,7 @@
     <string name="footer_end_of_statuses">fin du pouet</string>
     <string name="footer_end_of_notifications">fin des notifications</string>
     <string name="footer_end_of_accounts">fin des comptes</string>
-    <string name="footer_empty">There are no toots here so far. Pull down to refresh!</string>
+    <string name="footer_empty">Il n\'y à pas encore de pouet ici. Glissez vers le bas pour actualiser!</string>
 
     <string name="notification_reblog_format">%s a boosté votre pouet</string>
     <string name="notification_favourite_format">%s a ajouté votre pouet dans ses favoris</string>
@@ -81,7 +81,7 @@
     <string name="action_open_in_web">Ouvrir avec votre navigateur</string>
     <string name="action_submit">Envoyer</string>
     <string name="action_photo_pick">Ajouter un média</string>
-    <string name="action_photo_take">Take photo</string>
+    <string name="action_photo_take">Prendre une photo</string>
     <string name="action_share">Partager</string>
     <string name="action_mute">Rendre muet</string>
     <string name="action_unmute">Redonner la parole</string>
@@ -90,11 +90,11 @@
     <string name="action_compose_options">Option</string>
     <string name="action_open_drawer">Ouvrir le menu</string>
     <string name="action_clear">Nettoyer</string>
-    <string name="action_save">Save</string>
-    <string name="action_edit_profile">Edit profile</string>
+    <string name="action_save">Sauvegarder</string>
+    <string name="action_edit_profile">Modifier le profil</string>
 
     <string name="send_status_link_to">Partager l’URL de votre pouet avec…</string>
-    <string name="send_status_content_to">Share toot to…</string>
+    <string name="send_status_content_to">Partager le pouet avec…</string>
 
     <string name="search">Rechercher un compte…</string>
 
@@ -104,11 +104,11 @@
     <string name="hint_domain">Quelle instance ?</string>
     <string name="hint_compose">Quoi de neuf ?</string>
     <string name="hint_content_warning">Contenu sensible</string>
-    <string name="hint_display_name">Display name</string>
+    <string name="hint_display_name">Afficher le nom</string>
     <string name="hint_note">Bio</string>
 
     <string name="label_avatar">Avatar</string>
-    <string name="label_header">Header</string>
+    <string name="label_header">En-tête</string>
 
     <string name="link_whats_an_instance">Qu’est ce qu’une instance ?</string>
 
@@ -121,7 +121,7 @@
     </string>
     <string name="dialog_title_finishing_media_upload">Média mis en ligne avec succès</string>
     <string name="dialog_message_uploading_media">Mise en ligne…</string>
-    <string name="dialog_download_image">Download</string>
+    <string name="dialog_download_image">Télécharger</string>
 
     <string name="visibility_public">Public: Afficher dans les fils publics</string>
     <string name="visibility_unlisted">Non-listé: Ne pas afficher dans les fils publics</string>
@@ -153,6 +153,6 @@
     <string name="notification_title_summary">%d nouvelles interactions</string>
 
     <string name="description_account_locked">Compte bloqué</string>
-    <string name="status_share_content">Share content of toot</string>
-    <string name="status_share_link">Share link to toot</string>
+    <string name="status_share_content">Partager le conteunu du pouet</string>
+    <string name="status_share_link">Partager le lien du pouet</string>
 </resources>    

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,6 +1,7 @@
 <resources>
 
     <string name="error_generic">Une erreur s’est produite.</string>
+    <string name="error_empty">This cannot be empty.</string>
     <string name="error_invalid_domain">Le domaine est invalide</string>
     <string name="error_failed_app_registration">L’application n’a pu s’authentifier avec l’instance.</string>
     <string name="error_no_web_browser_found">Impossible de trouver un navigateur web.</string>
@@ -12,6 +13,8 @@
     <string name="error_media_upload_type">Ce type de fichier n’est pas accepté.</string>
     <string name="error_media_upload_opening">Le fichier ne peut être ouvert.</string>
     <string name="error_media_upload_permission">Une permission pour lire ce média est requise pour le mettre en ligne.</string>
+    <string name="error_media_download_permission">Permission to store media is required.</string>
+
     <string name="error_media_upload_image_or_video">Impossible de mettre une vidéo et une image sur le même pouet.</string>
     <string name="error_media_upload_sending">Ce média ne peut être mis en ligne.</string>
     <string name="error_report_too_few_statuses">Au moins un pouet a été reporté.</string>
@@ -38,6 +41,7 @@
     <string name="footer_end_of_statuses">fin du pouet</string>
     <string name="footer_end_of_notifications">fin des notifications</string>
     <string name="footer_end_of_accounts">fin des comptes</string>
+    <string name="footer_empty">There are no toots here so far. Pull down to refresh!</string>
 
     <string name="notification_reblog_format">%s a boosté votre pouet</string>
     <string name="notification_favourite_format">%s a ajouté votre pouet dans ses favoris</string>
@@ -46,10 +50,13 @@
     <string name="report_username_format">Signaler @%s</string>
     <string name="report_comment_hint">Davantage de commentaires ?</string>
 
+    <string name="action_reply">Répondre</string>
+    <string name="action_reblog">Booster</string>
+    <string name="action_favourite">Favori</string>
+    <string name="action_more">Plus</string>
     <string name="action_compose">Répondre</string>
     <string name="action_login">Se connecter avec Mastodon</string>
     <string name="action_logout">Déconnexion</string>
-
     <string name="action_follow">Suivre</string>
     <string name="action_unfollow">Ne plus suivre</string>
     <string name="action_block">Bloquer</string>
@@ -69,24 +76,25 @@
     <string name="action_view_preferences">Préferences</string>
     <string name="action_view_favourites">Favoris</string>
     <string name="action_view_blocks">Utilisateurs bloqués</string>
+    <string name="action_view_thread">Thread</string>
+    <string name="action_view_media">Media</string>
     <string name="action_open_in_web">Ouvrir avec votre navigateur</string>
     <string name="action_submit">Envoyer</string>
     <string name="action_photo_pick">Ajouter un média</string>
+    <string name="action_photo_take">Take photo</string>
     <string name="action_share">Partager</string>
     <string name="action_mute">Rendre muet</string>
     <string name="action_unmute">Redonner la parole</string>
     <string name="action_mention">Mention</string>
     <string name="toggle_nsfw">NSFW</string>
-    <string name="action_open_drawer">Ouvrir le menu</string>
-    <string name="action_more">Plus</string>
-    <string name="action_reply">Répondre</string>
-    <string name="action_view_media">Media</string>
-    <string name="action_favourite">Favori</string>
     <string name="action_compose_options">Option</string>
+    <string name="action_open_drawer">Ouvrir le menu</string>
     <string name="action_clear">Nettoyer</string>
-    <string name="action_reblog">Booster</string>
+    <string name="action_save">Save</string>
+    <string name="action_edit_profile">Edit profile</string>
 
-    <string name="send_status_to">Partager l’URL de votre pouet avec…</string>
+    <string name="send_status_link_to">Partager l’URL de votre pouet avec…</string>
+    <string name="send_status_content_to">Share toot to…</string>
 
     <string name="search">Rechercher un compte…</string>
 
@@ -96,6 +104,11 @@
     <string name="hint_domain">Quelle instance ?</string>
     <string name="hint_compose">Quoi de neuf ?</string>
     <string name="hint_content_warning">Contenu sensible</string>
+    <string name="hint_display_name">Display name</string>
+    <string name="hint_note">Bio</string>
+
+    <string name="label_avatar">Avatar</string>
+    <string name="label_header">Header</string>
 
     <string name="link_whats_an_instance">Qu’est ce qu’une instance ?</string>
 
@@ -108,6 +121,7 @@
     </string>
     <string name="dialog_title_finishing_media_upload">Média mis en ligne avec succès</string>
     <string name="dialog_message_uploading_media">Mise en ligne…</string>
+    <string name="dialog_download_image">Download</string>
 
     <string name="visibility_public">Public: Afficher dans les fils publics</string>
     <string name="visibility_unlisted">Non-listé: Ne pas afficher dans les fils publics</string>
@@ -139,4 +153,6 @@
     <string name="notification_title_summary">%d nouvelles interactions</string>
 
     <string name="description_account_locked">Compte bloqué</string>
+    <string name="status_share_content">Share content of toot</string>
+    <string name="status_share_link">Share link to toot</string>
 </resources>    

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -153,6 +153,6 @@
     <string name="notification_title_summary">%d nouvelles interactions</string>
 
     <string name="description_account_locked">Compte bloqué</string>
-    <string name="status_share_content">Partager le conteunu du pouet</string>
+    <string name="status_share_content">Partager le contenu du pouet</string>
     <string name="status_share_link">Partager le lien du pouet</string>
 </resources>    

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -13,6 +13,8 @@
     <string name="error_media_upload_type">その形式のファイルはアップロードできません。</string>
     <string name="error_media_upload_opening">ファイルを開けませんでした。</string>
     <string name="error_media_upload_permission">メディアの読み取り許可が必要です。</string>
+    <!-- <string name="error_media_download_permission">Permission to store media is required.</string> -->
+
     <string name="error_media_upload_image_or_video">画像と動画を同時に投稿することはできません。</string>
     <string name="error_media_upload_sending">アップロードに失敗しました。</string>
     <string name="error_report_too_few_statuses">少なくとも1つの投稿を報告してください。</string>
@@ -79,6 +81,7 @@
     <string name="action_open_in_web">ブラウザで開く</string>
     <string name="action_submit">決定</string>
     <string name="action_photo_pick">メディアを追加</string>
+    <!-- <string name="action_photo_take">Take photo</string> -->
     <string name="action_share">共有</string>
     <string name="action_mute">ミュート</string>
     <string name="action_unmute">ミュート解除</string>
@@ -87,6 +90,8 @@
     <string name="action_compose_options">オプション</string>
     <string name="action_open_drawer">メニューを開く</string>
     <string name="action_clear">消去</string>
+    <!-- <string name="action_save">Save</string> -->
+    <!-- <string name="action_edit_profile">Edit profile</string> -->
 
     <string name="send_status_link_to">トゥートのURLを共有…</string>
     <string name="send_status_content_to">トゥートを共有…</string>
@@ -99,6 +104,11 @@
     <string name="hint_domain">どのインスタンス？</string>
     <string name="hint_compose">今なにしてる？</string>
     <string name="hint_content_warning">注意書き</string>
+    <!-- <string name="hint_display_name">Display name</string> -->
+    <!-- <string name="hint_note">Bio</string> -->
+
+    <!-- <string name="label_avatar">Avatar</string> -->
+    <!-- <string name="label_header">Header</string> -->
 
     <string name="link_whats_an_instance">インスタンスとは？</string>
 
@@ -112,10 +122,12 @@
     </string>
     <string name="dialog_title_finishing_media_upload">メディアをアップロードしています</string>
     <string name="dialog_message_uploading_media">アップロード中…</string>
+    <!-- <string name="dialog_download_image">Download</string> -->
 
     <string name="visibility_public">全体へ公開</string>
     <string name="visibility_unlisted">全体へ公開するが、公開タイムラインには表示しない</string>
     <string name="visibility_private">フォロワーと返信先にのみに表示</string>
+    <!-- <string name="visibility_direct">Direct: Post to mentioned users only</string> -->
 
     <string name="pref_title_notification_settings">通知</string>
     <string name="pref_title_edit_notification_settings">通知を設定</string>
@@ -144,5 +156,4 @@
     <string name="description_account_locked">非公開アカウント</string>
     <string name="status_share_content">トゥートの内容を共有</string>
     <string name="status_share_link">トゥートへのリンクを共有</string>
-
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -13,6 +13,8 @@
     <string name="error_media_upload_type">Bestandstype kan niet worden geüpload.</string>
     <string name="error_media_upload_opening">Bestand kan niet worden geopend.</string>
     <string name="error_media_upload_permission">Toestemming nodig om media te kunnen lezen.</string>
+    <!-- <string name="error_media_download_permission">Permission to store media is required.</string> -->
+
     <string name="error_media_upload_image_or_video">Afbeeldingen en video\'s kunnen niet allebei aan dezelfde toot worden toegevoegd.</string>
     <string name="error_media_upload_sending">Uploaden mislukt.</string>
     <string name="error_report_too_few_statuses">Tenminste één toot moet worden gerapporteerd.</string>
@@ -87,6 +89,8 @@
     <string name="action_compose_options">Opties</string>
     <string name="action_open_drawer">Menu openen</string>
     <string name="action_clear">Leegmaken</string>
+    <!-- <string name="action_save">Save</string> -->
+    <!-- <string name="action_edit_profile">Edit profile</string> -->
 
     <string name="send_status_link_to">Deel link van toot met…</string>
     <string name="send_status_content_to">Deel toot met…</string>
@@ -99,6 +103,11 @@
     <string name="hint_domain">Welke Mastodon-server?</string>
     <string name="hint_compose">Wat wil je kwijt?</string>
     <string name="hint_content_warning">Waarschuwingstekst</string>
+    <!-- <string name="hint_display_name">Display name</string> -->
+    <!-- <string name="hint_note">Bio</string> -->
+
+    <!-- <string name="label_avatar">Avatar</string> -->
+    <!-- <string name="label_header">Header</string> -->
 
     <string name="link_whats_an_instance">Wat is een Mastodon-server?</string>
 
@@ -108,10 +117,12 @@
     </string>
     <string name="dialog_title_finishing_media_upload">Uploaden media wordt voltooid</string>
     <string name="dialog_message_uploading_media">Uploaden…</string>
+    <!-- <string name="dialog_download_image">Download</string> -->
 
-    <string name="visibility_public">Openbaar</string>
+	<string name="visibility_public">Openbaar</string>
     <string name="visibility_unlisted">Openbaar, maar niet op een openbare tijdlijn tonen</string>
     <string name="visibility_private">Alleen aan volgers (en vermeldingen) tonen</string>
+    <!-- <string name="visibility_direct">Direct: Post to mentioned users only</string> -->
 
     <string name="pref_title_notification_settings">Meldingen</string>
     <string name="pref_title_edit_notification_settings">Meldingen bewerken</string>
@@ -140,5 +151,4 @@
     <string name="description_account_locked">Geblokkeerde account</string>
     <string name="status_share_content">Deel inhoud van toot</string>
     <string name="status_share_link">Deel link met toot</string>
-
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -13,7 +13,7 @@
     <string name="error_media_upload_type">O biçim dosya yüklenmez.</string>
     <string name="error_media_upload_opening">O dosya açılamadı.</string>
     <string name="error_media_upload_permission">Medya okuma izni gerekiyor.</string>
-    <string name="error_media_download_permission">Permission to store media is required.</string>
+    <string name="error_media_download_permission">Medya kaydetmek için izin gerekiyor.</string>
 
     <string name="error_media_upload_image_or_video">Aynı iletiye kem video hem resim eklenemez.</string>
     <string name="error_media_upload_sending">Yükleme başarsız.</string>
@@ -81,7 +81,7 @@
     <string name="action_open_in_web">Tarayıcıda aç</string>
     <string name="action_submit">Gönder</string>
     <string name="action_photo_pick">Medya ekle</string>
-    <string name="action_photo_take">Take photo</string>
+    <string name="action_photo_take">Resim çek</string>
     <string name="action_share">Paylaş</string>
     <string name="action_mute">Sesize al</string>
     <string name="action_unmute">Sesizden kaldır</string>
@@ -90,8 +90,8 @@
     <string name="action_compose_options">Seçenekler</string>
     <string name="action_open_drawer">Çekmece aç</string>
     <string name="action_clear">Temizle</string>
-    <string name="action_save">Save</string>
-    <string name="action_edit_profile">Edit profile</string>
+    <string name="action_save">Kaydet</string>
+    <string name="action_edit_profile">Profili düzelt</string>
 
     <string name="send_status_link_to">İletinin adresini paylaş…</string>
     <string name="send_status_content_to">İletiyi paylaş…</string>
@@ -104,11 +104,11 @@
     <string name="hint_domain">Hangi sunucu?</string>
     <string name="hint_compose">Neler oluyor?</string>
     <string name="hint_content_warning">İçerik uyarı</string>
-    <string name="hint_display_name">Display name</string>
-    <string name="hint_note">Bio</string>
+    <string name="hint_display_name">Görünen ad</string>
+    <string name="hint_note">Biyo</string>
 
-    <string name="label_avatar">Avatar</string>
-    <string name="label_header">Header</string>
+    <string name="label_avatar">Simge</string>
+    <string name="label_header">Üstlük</string>
 
     <string name="link_whats_an_instance">Sunucu nedir?</string>
 
@@ -122,12 +122,12 @@
     </string>
     <string name="dialog_title_finishing_media_upload">Medya Yükleme Bittiriliyor</string>
     <string name="dialog_message_uploading_media">Yükleniyor…</string>
-    <string name="dialog_download_image">Download</string>
+    <string name="dialog_download_image">İndir</string>
 
-    <string name="visibility_public">Herkese açık</string>
-    <string name="visibility_unlisted">Kerkese açık ancak sosyal çizelgesinde çıkmaz</string>
-    <string name="visibility_private">Sadece takipçiler ve bahsedilenlere açık</string>
-    <string name="visibility_direct">Direct: Post to mentioned users only</string>
+    <string name="visibility_public">Kamu: Herkese açık ve sosyal çizelgelerinde çıkar</string>
+    <string name="visibility_unlisted">Saklı: Herkese açık ancık sosyal çizelgesinde çıkmaz</string>
+    <string name="visibility_private">Özel: Sadece takipçiler ve bahsedilenlere açık</string>
+    <string name="visibility_direct">Direkt: Sadece bahsedilen kullanıcılara açık</string>
 
     <string name="pref_title_notification_settings">Bildirimler</string>
     <string name="pref_title_edit_notification_settings">Bildirimleri düzelt</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -13,6 +13,8 @@
     <string name="error_media_upload_type">O biçim dosya yüklenmez.</string>
     <string name="error_media_upload_opening">O dosya açılamadı.</string>
     <string name="error_media_upload_permission">Medya okuma izni gerekiyor.</string>
+    <string name="error_media_download_permission">Permission to store media is required.</string>
+
     <string name="error_media_upload_image_or_video">Aynı iletiye kem video hem resim eklenemez.</string>
     <string name="error_media_upload_sending">Yükleme başarsız.</string>
     <string name="error_report_too_few_statuses">Her bildirme en azından bir iletiyi işaret etmeli.</string>
@@ -79,6 +81,7 @@
     <string name="action_open_in_web">Tarayıcıda aç</string>
     <string name="action_submit">Gönder</string>
     <string name="action_photo_pick">Medya ekle</string>
+    <string name="action_photo_take">Take photo</string>
     <string name="action_share">Paylaş</string>
     <string name="action_mute">Sesize al</string>
     <string name="action_unmute">Sesizden kaldır</string>
@@ -87,6 +90,8 @@
     <string name="action_compose_options">Seçenekler</string>
     <string name="action_open_drawer">Çekmece aç</string>
     <string name="action_clear">Temizle</string>
+    <string name="action_save">Save</string>
+    <string name="action_edit_profile">Edit profile</string>
 
     <string name="send_status_link_to">İletinin adresini paylaş…</string>
     <string name="send_status_content_to">İletiyi paylaş…</string>
@@ -99,10 +104,15 @@
     <string name="hint_domain">Hangi sunucu?</string>
     <string name="hint_compose">Neler oluyor?</string>
     <string name="hint_content_warning">İçerik uyarı</string>
+    <string name="hint_display_name">Display name</string>
+    <string name="hint_note">Bio</string>
+
+    <string name="label_avatar">Avatar</string>
+    <string name="label_header">Header</string>
 
     <string name="link_whats_an_instance">Sunucu nedir?</string>
 
-	<string name="dialog_whats_an_instance">Burada her hangi bir Mastodon sunucusunun adresi
+    <string name="dialog_whats_an_instance">Burada her hangi bir Mastodon sunucusunun adresi
 		(mastodon.social, icosahedron.website, social.tchncs.de, ve
         <a href="https://github.com/tootsuite/mastodon/blob/master/docs/Using-Mastodon/List-of-Mastodon-instances.md">daha fazla!</a>) girilebiliri.
 		\n\nEğer hesabınız henüz yok ise katılmak istediğiniz sunucunun adresini girerek hesap yaratabilirsin.
@@ -112,10 +122,12 @@
     </string>
     <string name="dialog_title_finishing_media_upload">Medya Yükleme Bittiriliyor</string>
     <string name="dialog_message_uploading_media">Yükleniyor…</string>
+    <string name="dialog_download_image">Download</string>
 
     <string name="visibility_public">Herkese açık</string>
     <string name="visibility_unlisted">Kerkese açık ancak sosyal çizelgesinde çıkmaz</string>
     <string name="visibility_private">Sadece takipçiler ve bahsedilenlere açık</string>
+    <string name="visibility_direct">Direct: Post to mentioned users only</string>
 
     <string name="pref_title_notification_settings">Bildirimler</string>
     <string name="pref_title_edit_notification_settings">Bildirimleri düzelt</string>
@@ -144,5 +156,4 @@
     <string name="description_account_locked">Kitli Hesap</string>
     <string name="status_share_content">İletinin içeriğini paylaş</string>
     <string name="status_share_link">İletinin adresini paylaş</string>
-
 </resources>


### PR DESCRIPTION
Since most of the translations were initially started new features have been added requiring new strings. Also the strings were re-arranged a bit.

I went through all the existing translations and made sure the keys match the original. For ones that were missing, I added the current English strings. Where applicable I also organized them to be in the same order for easy comparison.

Note this highlights what translators need to catch up on for new strings, but it doesn't show off where strings have been edited. In particular they should review the `visibility_*` strings and `dialog_whats_an_instance` as those seem to be the most significant  changes.

I brought the TR strings up to date, but after this merges we should ping other translators to review their languages.