### PR TITLE
use material design icon for local timeline tab

### DIFF
--- a/app/src/main/res/drawable/ic_local_24dp.xml
+++ b/app/src/main/res/drawable/ic_local_24dp.xml
@@ -1,27 +1,7 @@
-<vector android:height="24dp" android:viewportHeight="42.519684"
-    android:viewportWidth="42.519684" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillAlpha="1" android:fillColor="#ffffff"
-        android:pathData="M31.89,5.82m-5.31,0a5.31,5.31 0,1 1,10.63 0a5.31,5.31 0,1 1,-10.63 0"
-        android:strokeAlpha="1" android:strokeColor="#00000000"
-        android:strokeLineCap="square" android:strokeLineJoin="miter" android:strokeWidth="0.30000001"/>
-    <path android:fillAlpha="1" android:fillColor="#ffffff"
-        android:pathData="M10.63,5.82m-5.31,0a5.31,5.31 0,1 1,10.63 0a5.31,5.31 0,1 1,-10.63 0"
-        android:strokeAlpha="1" android:strokeColor="#00000000"
-        android:strokeLineCap="square" android:strokeLineJoin="miter" android:strokeWidth="0.30000001"/>
-    <path android:fillAlpha="1" android:fillColor="#ffffff"
-        android:pathData="M21.26,23.03m-5.31,0a5.31,5.31 0,1 1,10.63 0a5.31,5.31 0,1 1,-10.63 0"
-        android:strokeAlpha="1" android:strokeColor="#00000000"
-        android:strokeLineCap="square" android:strokeLineJoin="miter" android:strokeWidth="0.30000001"/>
-    <path android:fillAlpha="1" android:fillColor="#ffffff"
-        android:pathData="m17.62,29.22c-2.07,1.24 -3.45,3.49 -3.45,6.08l0,3.54c0,3.93 -0.38,3.54 3.54,3.54l7.09,0c3.93,0 3.54,0.38 3.54,-3.54l0,-3.54c0,-2.59 -1.38,-4.84 -3.45,-6.08a7.19,7.19 0,0 1,-3.64 1,7.19 7.19,0 0,1 -3.64,-1z"
-        android:strokeAlpha="1" android:strokeColor="#00000000"
-        android:strokeLineCap="square" android:strokeLineJoin="miter" android:strokeWidth="0.30000001"/>
-    <path android:fillAlpha="1" android:fillColor="#ffffff"
-        android:pathData="m28.25,12.04c-1.69,1.01 -2.91,2.72 -3.3,4.72a7.28,7.28 0,0 1,3.59 6.27,7.28 7.28,0 0,1 -0.33,2.18c0.06,-0 0.08,0 0.14,0l7.09,0c3.93,0 3.54,0.38 3.54,-3.54l0,-3.54c0,-2.59 -1.38,-4.84 -3.45,-6.08a7.19,7.19 0,0 1,-3.64 1,7.19 7.19,0 0,1 -3.64,-1z"
-        android:strokeAlpha="1" android:strokeColor="#00000000"
-        android:strokeLineCap="square" android:strokeLineJoin="miter" android:strokeWidth="0.30000001"/>
-    <path android:fillAlpha="1" android:fillColor="#ffffff"
-        android:pathData="m6.99,12.04c-2.07,1.24 -3.45,3.49 -3.45,6.08l0,3.54c0,3.93 -0.38,3.54 3.54,3.54l7.09,0c0.07,0 0.08,-0 0.15,0a7.28,7.28 0,0 1,-0.34 -2.18,7.28 7.28,0 0,1 3.59,-6.27c-0.39,-2.01 -1.61,-3.71 -3.3,-4.72a7.19,7.19 0,0 1,-3.64 1,7.19 7.19,0 0,1 -3.64,-1z"
-        android:strokeAlpha="1" android:strokeColor="#00000000"
-        android:strokeLineCap="square" android:strokeLineJoin="miter" android:strokeWidth="0.30000001"/>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="#000" android:pathData="M16,13C15.71,13 15.38,13 15.03,13.05C16.19,13.89 17,15 17,16.5V19H23V16.5C23,14.17 18.33,13 16,13M8,13C5.67,13 1,14.17 1,16.5V19H15V16.5C15,14.17 10.33,13 8,13M8,11A3,3 0 0,0 11,8A3,3 0 0,0 8,5A3,3 0 0,0 5,8A3,3 0 0,0 8,11M16,11A3,3 0 0,0 19,8A3,3 0 0,0 16,5A3,3 0 0,0 13,8A3,3 0 0,0 16,11Z" />
 </vector>


### PR DESCRIPTION
fits much better with the other material design icons

before:
![screen-1](https://cloud.githubusercontent.com/assets/10157047/25303287/ea8e9258-274f-11e7-9649-6377bd3b6537.png)

after:
![screen-2](https://cloud.githubusercontent.com/assets/10157047/25303288/ece452c2-274f-11e7-84ee-bdb8a160d57f.png)

