### PR TITLE
TuskyApplication: call super.onCreate()

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/TuskyApplication.java
+++ b/app/src/main/java/com/keylesspalace/tusky/TuskyApplication.java
@@ -24,6 +24,7 @@ import com.jakewharton.picasso.OkHttp3Downloader;
 public class TuskyApplication extends Application {
     @Override
     public void onCreate() {
+        super.onCreate();
         // Initialize Picasso configuration
         Picasso.Builder builder = new Picasso.Builder(this);
         builder.downloader(new OkHttp3Downloader(this));


### PR DESCRIPTION
Although for now it makes no difference calling super.onCreate or not
(the method Application.onCreate() is empty), it is denoted with
@CallSuper and might cause errors in some IDE if it is not called.