### PR TITLE
Fixed issues #190 & #259 screen orientation in MainActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,7 +37,9 @@
                     android:scheme="@string/oauth_scheme" />
             </intent-filter>
         </activity>
-        <activity android:name=".MainActivity" />
+        <activity
+            android:name=".MainActivity" android:configChanges="orientation|screenSize|keyboardHidden">
+        </activity>
         <activity
             android:name=".ComposeActivity"
             android:windowSoftInputMode="stateVisible|adjustResize">

--- a/app/src/main/java/com/keylesspalace/tusky/MainActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/MainActivity.java
@@ -18,6 +18,7 @@ package com.keylesspalace.tusky;
 import android.app.NotificationManager;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.res.Configuration;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
@@ -552,5 +553,11 @@ public class MainActivity extends BaseActivity implements SFragment.OnUserRemove
                 listener.removePostsByUser(accountId);
             }
         }
+    }
+
+    // Fix for GitHub issues #190, #259 (MainActivity won't restart on screen rotation.)
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
     }
 }


### PR DESCRIPTION
I added an onConfigurationChanged() listener to MainActivity class so that when you change the orientation of the screen the Activity doesn't get destroyed. This fixes issues 190 & 259 that both relate to changing screen orientation while running Tusky.

The diffs look worse than they should due I think to the difference in line end characters, between my version of the files and the original version.