### PR TITLE
fixed crash when MediaAttachment.Type is unknown

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/entity/Status.java
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/Status.java
@@ -148,11 +148,11 @@ public class Status {
             public Type deserialize(JsonElement json, java.lang.reflect.Type classOfT, JsonDeserializationContext context)
                     throws JsonParseException {
                 switch(json.toString()) {
-                    case "image":
+                    case "\"image\"":
                         return Type.IMAGE;
-                    case "gifv":
+                    case "\"gifv\"":
                         return Type.GIFV;
-                    case "video":
+                    case "\"video\"":
                         return Type.VIDEO;
                     default:
                         return Type.UNKNOWN;

--- a/app/src/main/java/com/keylesspalace/tusky/entity/Status.java
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/Status.java
@@ -17,6 +17,10 @@ package com.keylesspalace.tusky.entity;
 
 import android.text.Spanned;
 
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
 import com.google.gson.annotations.SerializedName;
 
 import java.util.Date;
@@ -115,6 +119,7 @@ public class Status {
     }
 
     public static class MediaAttachment {
+        @com.google.gson.annotations.JsonAdapter(MediaTypeDeserializer.class)
         public enum Type {
             @SerializedName("image")
             IMAGE,
@@ -122,7 +127,7 @@ public class Status {
             GIFV,
             @SerializedName("video")
             VIDEO,
-            UNKNOWN,
+            UNKNOWN
         }
 
         public String url;
@@ -137,6 +142,23 @@ public class Status {
         public String remoteUrl;
 
         public Type type;
+
+        static class MediaTypeDeserializer implements JsonDeserializer<Type> {
+            @Override
+            public Type deserialize(JsonElement json, java.lang.reflect.Type classOfT, JsonDeserializationContext context)
+                    throws JsonParseException {
+                switch(json.toString()) {
+                    case "image":
+                        return Type.IMAGE;
+                    case "gifv":
+                        return Type.GIFV;
+                    case "video":
+                        return Type.VIDEO;
+                    default:
+                        return Type.UNKNOWN;
+                }
+            }
+        }
     }
 
     public static class Mention {
@@ -150,4 +172,6 @@ public class Status {
         @SerializedName("username")
         public String localUsername;
     }
+
+
 }


### PR DESCRIPTION
fixes https://github.com/Vavassor/Tusky/issues/265
While this specific crash could be fixed with  `@SerializedName("unknown")`, I decided to go with a custom JsonDeserializer to make sure the MediaAttachment.TYPE is always set to UNKNOWN if the json could not be mapped to the enum.