### PR TITLE
use TextInputEditText instead of EditText inside TextInputLayout

### DIFF
--- a/app/src/main/res/layout/activity_edit_profile.xml
+++ b/app/src/main/res/layout/activity_edit_profile.xml
@@ -86,7 +86,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="30dp">
 
-                <EditText
+                <android.support.design.widget.TextInputEditText
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:id="@+id/edit_profile_display_name"
@@ -103,7 +103,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="30dp">
 
-                <EditText
+                <android.support.design.widget.TextInputEditText
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:id="@+id/edit_profile_note"

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -23,7 +23,7 @@
         <android.support.design.widget.TextInputLayout
             android:layout_height="wrap_content"
             android:layout_width="250dp">
-            <EditText
+            <android.support.design.widget.TextInputEditText
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:inputType="textUri"


### PR DESCRIPTION
TextInputLayout is intended to be used with TextInputEditText

https://developer.android.com/reference/android/support/design/widget/TextInputLayout.html
