### PR TITLE
fixed light theme header background when no header image is set

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/MainActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/MainActivity.java
@@ -29,6 +29,7 @@ import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.TabLayout;
 import android.support.graphics.drawable.VectorDrawableCompat;
 import android.support.v4.app.Fragment;
+import android.support.v4.content.ContextCompat;
 import android.support.v4.view.ViewPager;
 import android.text.SpannableStringBuilder;
 import android.text.Spanned;
@@ -478,6 +479,8 @@ public class MainActivity extends BaseActivity implements SFragment.OnUserRemove
             backgroundWidth = background.getMeasuredWidth();
             backgroundHeight = background.getMeasuredHeight();
         }
+
+        background.setBackgroundColor(ContextCompat.getColor(this, R.color.window_background_dark));
 
         Picasso.with(MainActivity.this)
                 .load(me.header)


### PR DESCRIPTION
before - unreadable
![screenshot_2017-05-05-17-02-04](https://cloud.githubusercontent.com/assets/10157047/25752258/034e7dcc-31b8-11e7-80fc-2106d26bcd96.png)

after
![screenshot_2017-05-05-17-18-55](https://cloud.githubusercontent.com/assets/10157047/25752248/fe084384-31b7-11e7-940a-e4c71d775afa.png)

