### PR TITLE
Add loading on login activity while fetching tokens

### DIFF
--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -20,39 +20,63 @@
             android:src="@drawable/elephant_friend"
             android:contentDescription="@null" />
 
-        <android.support.design.widget.TextInputLayout
+        <LinearLayout
+            android:id="@+id/login_input"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_width="250dp">
-            <android.support.design.widget.TextInputEditText
-                android:layout_width="match_parent"
+            android:orientation="vertical">
+            <android.support.design.widget.TextInputLayout
                 android:layout_height="wrap_content"
-                android:inputType="textUri"
-                android:hint="@string/hint_domain"
-                android:ems="10"
-                android:id="@+id/edit_text_domain" />
-        </android.support.design.widget.TextInputLayout>
+                android:layout_width="250dp">
+                <android.support.design.widget.TextInputEditText
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="textUri"
+                    android:hint="@string/hint_domain"
+                    android:ems="10"
+                    android:id="@+id/edit_text_domain" />
+            </android.support.design.widget.TextInputLayout>
 
-        <Button
-            android:id="@+id/button_login"
-            android:layout_width="250dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="4dp"
-            android:textColor="@android:color/white"
-            android:text="@string/action_login" />
+            <Button
+                android:id="@+id/button_login"
+                android:layout_width="250dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:textColor="@android:color/white"
+                android:text="@string/action_login" />
 
-        <TextView
-            android:layout_width="250dp"
-            android:layout_height="wrap_content"
+            <TextView
+                android:layout_width="250dp"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                android:id="@+id/text_error" />
+
+            <TextView
+                android:layout_width="250dp"
+                android:layout_height="wrap_content"
+                android:paddingTop="5dp"
+                android:textAlignment="center"
+                android:id="@+id/whats_an_instance"
+                android:text="@string/link_whats_an_instance" />
+        </LinearLayout>
+        <LinearLayout
+            android:id="@+id/login_loading"
             android:visibility="gone"
-            android:id="@+id/text_error" />
+            android:orientation="vertical"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content">
+            <ProgressBar
+                android:layout_gravity="center"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+            <TextView
+                android:paddingTop="10dp"
+                android:textAlignment="center"
+                android:layout_width="250dp"
+                android:layout_height="wrap_content"
+                android:text="@string/login_connection"/>
+        </LinearLayout>
 
-        <TextView
-            android:layout_width="250dp"
-            android:layout_height="wrap_content"
-            android:paddingTop="5dp"
-            android:textAlignment="center"
-            android:id="@+id/whats_an_instance"
-            android:text="@string/link_whats_an_instance" />
 
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -111,6 +111,8 @@
 
     <string name="link_whats_an_instance">Qu’est-ce qu’une instance ?</string>
 
+    <string name="login_connection">Connexion en cours…</string>
+
     <string name="dialog_whats_an_instance">Indiquer ici l’adresse ou le domaine d’une instance, comme mastodon.social, icosahedron.website, social.tchncs.de,
         <a href="https://github.com/tootsuite/mastodon/blob/master/docs/Using-Mastodon/List-of-Mastodon-instances.md">et bien d’autres encore</a> (en anglais) !
         \n\nSi vous ne disposez d’aucun compte, vous pouvez renseigner le nom de l’instance que vous souhaitez rejoindre et y créer un compte.\n\nUne instance est l’endroit où votre compte est

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -122,6 +122,8 @@
 
     <string name="link_whats_an_instance">What\'s an instance?</string>
 
+    <string name="login_connection">Connecting…</string>
+
     <string name="dialog_whats_an_instance">The address or domain of any instance can be entered
         here, such as mastodon.social, icosahedron.website, social.tchncs.de, and
         <a href="https://github.com/tootsuite/mastodon/blob/master/docs/Using-Mastodon/List-of-Mastodon-instances.md">more!</a>


### PR DESCRIPTION
When coming from the chrome tab, the app was still showing the domain input for ~1 second before switching to the main activity. Now, the app shows a progress bar during this period.

I am not really aware of the naming convention, so don't hesitate to request some changes.

![French Version](https://cloud.githubusercontent.com/assets/9824244/25800398/b9c216f0-33d8-11e7-8660-b5592f8f9c1d.png)

