### PR TITLE
Allow broadcasting event across activities, closes #280

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/AccountActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/AccountActivity.java
@@ -32,6 +32,7 @@ import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.Snackbar;
 import android.support.design.widget.TabLayout;
 import android.support.v4.app.Fragment;
+import android.support.v4.content.LocalBroadcastManager;
 import android.support.v4.view.ViewCompat;
 import android.support.v4.view.ViewPager;
 import android.support.v7.app.ActionBar;
@@ -51,6 +52,7 @@ import com.keylesspalace.tusky.pager.AccountPagerAdapter;
 import com.keylesspalace.tusky.util.LinkHelper;
 import com.keylesspalace.tusky.util.Assert;
 import com.keylesspalace.tusky.util.Log;
+import com.keylesspalace.tusky.util.TimelineReceiver;
 import com.keylesspalace.tusky.util.ThemeUtils;
 import com.pkmmte.view.CircularImageView;
 import com.squareup.picasso.Picasso;
@@ -467,6 +469,7 @@ public class AccountActivity extends BaseActivity implements SFragment.OnUserRem
                                 Snackbar.LENGTH_LONG).show();
                     } else {
                         followState = FollowState.NOT_FOLLOWING;
+                        broadcast(TimelineReceiver.Types.UNFOLLOW_ACCOUNT, id);
                     }
                     updateButtons();
                 } else {
@@ -517,6 +520,7 @@ public class AccountActivity extends BaseActivity implements SFragment.OnUserRem
             @Override
             public void onResponse(Call<Relationship> call, Response<Relationship> response) {
                 if (response.isSuccessful()) {
+                    broadcast(TimelineReceiver.Types.BLOCK_ACCOUNT, id);
                     blocking = response.body().blocking;
                     updateButtons();
                 } else {
@@ -554,6 +558,7 @@ public class AccountActivity extends BaseActivity implements SFragment.OnUserRem
             @Override
             public void onResponse(Call<Relationship> call, Response<Relationship> response) {
                 if (response.isSuccessful()) {
+                    broadcast(TimelineReceiver.Types.MUTE_ACCOUNT, id);
                     muting = response.body().muting;
                     updateButtons();
                 } else {
@@ -586,6 +591,11 @@ public class AccountActivity extends BaseActivity implements SFragment.OnUserRem
                 .show();
     }
 
+    private void broadcast(String action, String id) {
+        Intent intent = new Intent(action);
+        intent.putExtra("id", id);
+        LocalBroadcastManager.getInstance(getApplicationContext()).sendBroadcast(intent);
+    }
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
@@ -23,6 +23,7 @@ import android.preference.PreferenceManager;
 import android.support.annotation.Nullable;
 import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.TabLayout;
+import android.support.v4.content.LocalBroadcastManager;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.widget.DividerItemDecoration;
 import android.support.v7.widget.LinearLayoutManager;
@@ -39,6 +40,7 @@ import com.keylesspalace.tusky.interfaces.StatusActionListener;
 import com.keylesspalace.tusky.interfaces.StatusRemoveListener;
 import com.keylesspalace.tusky.util.EndlessOnScrollListener;
 import com.keylesspalace.tusky.util.Log;
+import com.keylesspalace.tusky.util.TimelineReceiver;
 import com.keylesspalace.tusky.util.ThemeUtils;
 
 import java.util.List;
@@ -72,6 +74,7 @@ public class TimelineFragment extends SFragment implements
     private EndlessOnScrollListener scrollListener;
     private TabLayout.OnTabSelectedListener onTabSelectedListener;
     private boolean hideFab;
+    private TimelineReceiver timelineReceiver;
 
     public static TimelineFragment newInstance(Kind kind) {
         TimelineFragment fragment = new TimelineFragment();
@@ -120,6 +123,8 @@ public class TimelineFragment extends SFragment implements
         adapter = new TimelineAdapter(this);
         recyclerView.setAdapter(adapter);
 
+        timelineReceiver = new TimelineReceiver(adapter);
+        LocalBroadcastManager.getInstance(context.getApplicationContext()).registerReceiver(timelineReceiver, TimelineReceiver.getFilter(kind));
         return rootView;
     }
 
@@ -204,6 +209,7 @@ public class TimelineFragment extends SFragment implements
             TabLayout tabLayout = (TabLayout) getActivity().findViewById(R.id.tab_layout);
             tabLayout.removeOnTabSelectedListener(onTabSelectedListener);
         }
+        LocalBroadcastManager.getInstance(getContext()).unregisterReceiver(timelineReceiver);
         super.onDestroyView();
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/util/TimelineReceiver.java
+++ b/app/src/main/java/com/keylesspalace/tusky/util/TimelineReceiver.java
@@ -1,0 +1,41 @@
+package com.keylesspalace.tusky.util;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+
+import com.keylesspalace.tusky.adapter.TimelineAdapter;
+import com.keylesspalace.tusky.fragment.TimelineFragment;
+
+public class TimelineReceiver extends BroadcastReceiver {
+    public static final class Types {
+        public static final String UNFOLLOW_ACCOUNT = "UNFOLLOW_ACCOUNT";
+        public static final String BLOCK_ACCOUNT = "BLOCK_ACCOUNT";
+        public static final String MUTE_ACCOUNT = "MUTE_ACCOUNT";
+    }
+
+    TimelineAdapter adapter;
+
+    public TimelineReceiver(TimelineAdapter adapter) {
+        super();
+        this.adapter = adapter;
+    }
+
+    @Override
+    public void onReceive(Context context, final Intent intent) {
+        String id = intent.getStringExtra("id");
+        adapter.removeAllByAccountId(id);
+    }
+
+    public static IntentFilter getFilter(TimelineFragment.Kind kind) {
+        IntentFilter intentFilter = new IntentFilter();
+        if (kind == TimelineFragment.Kind.HOME) {
+            intentFilter.addAction(Types.UNFOLLOW_ACCOUNT);
+        }
+        intentFilter.addAction(Types.BLOCK_ACCOUNT);
+        intentFilter.addAction(Types.MUTE_ACCOUNT);
+
+        return intentFilter;
+    }
+}


### PR DESCRIPTION
Implements removing statuses of a user from home timeline when unfollowing, and from all timelines when muting/blocking.

There is still work to be done in order to sync favourite and reblog.

I don't know if it should have the same behavior when muting and blocking. I did not get the difference.
Also, I don't if it is relevent to put `TimelineReceiver` in the `util` package, maybe it should be in `adapter`.
