### PR TITLE
fix bug in CollapsingToolbarLayout / OnOffsetChangedListener / AccountActivity

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/AccountActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/AccountActivity.java
@@ -20,6 +20,7 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Bundle;
@@ -136,23 +137,17 @@ public class AccountActivity extends BaseActivity implements SFragment.OnUserRem
                 @AttrRes int attribute;
                 if (collapsingToolbar.getHeight() + verticalOffset
                         < 2 * ViewCompat.getMinimumHeight(collapsingToolbar)) {
-                    if (getSupportActionBar() != null && loadedAccount != null) {
-                        getSupportActionBar().setTitle(loadedAccount.getDisplayName());
+
                         toolbar.setTitleTextColor(ThemeUtils.getColor(AccountActivity.this,
                                 android.R.attr.textColorPrimary));
-
-                        String subtitle = String.format(getString(R.string.status_username_format),
-                                loadedAccount.username);
-                        getSupportActionBar().setSubtitle(subtitle);
                         toolbar.setSubtitleTextColor(ThemeUtils.getColor(AccountActivity.this,
                                 android.R.attr.textColorSecondary));
-                    }
+
                     attribute = R.attr.account_toolbar_icon_tint_collapsed;
                 } else {
-                    if (getSupportActionBar() != null) {
-                        getSupportActionBar().setTitle("");
-                        getSupportActionBar().setSubtitle("");
-                    }
+                    toolbar.setTitleTextColor(Color.TRANSPARENT);
+                    toolbar.setSubtitleTextColor(Color.TRANSPARENT);
+
                     attribute = R.attr.account_toolbar_icon_tint_uncollapsed;
                 }
                 if (attribute != priorAttribute) {
@@ -244,6 +239,15 @@ public class AccountActivity extends BaseActivity implements SFragment.OnUserRem
         username.setText(usernameFormatted);
 
         displayName.setText(account.getDisplayName());
+
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().setTitle(account.getDisplayName());
+
+            String subtitle = String.format(getString(R.string.status_username_format),
+                    account.username);
+            getSupportActionBar().setSubtitle(subtitle);
+
+        }
 
         boolean useCustomTabs = PreferenceManager.getDefaultSharedPreferences(this)
                 .getBoolean("customTabs", true);


### PR DESCRIPTION
To reproduce the bug, go to AccountActivity, scroll up so the toolbar collapses.
Look at the console output, it gets spammed with 

```
05-25 18:57:56.857 18678-18678/com.keylesspalace.tusky W/View: requestLayout() improperly called by android.support.v7.widget.AppCompatTextView{25ba0001 V.ED.... ........ 108,47-417,78} during second layout pass: posting in next frame
05-25 18:57:56.865 18678-18678/com.keylesspalace.tusky W/View: requestLayout() improperly called by android.support.design.widget.CollapsingToolbarLayout{25482f0b V.ED.... ......ID 0,0-540,379 #7f0e009e app:id/collapsing_toolbar} during layout: running second layout pass
```
or take a look at the cpu usage - 😳

this PR fixes the problem

@raphaelm I think you implemented this initially