### PR TITLE
Add boost click handling

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/adapter/AccountViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/AccountViewHolder.java
@@ -17,7 +17,7 @@ class AccountViewHolder extends RecyclerView.ViewHolder {
     private TextView username;
     private TextView displayName;
     private CircularImageView avatar;
-    private String id;
+    private String accountId;
 
     AccountViewHolder(View itemView) {
         super(itemView);
@@ -28,7 +28,7 @@ class AccountViewHolder extends RecyclerView.ViewHolder {
     }
 
     void setupWithAccount(Account account) {
-        id = account.id;
+        accountId = account.id;
         String format = username.getContext().getString(R.string.status_username_format);
         String formattedUsername = String.format(format, account.username);
         username.setText(formattedUsername);
@@ -45,7 +45,7 @@ class AccountViewHolder extends RecyclerView.ViewHolder {
         container.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                listener.onViewAccount(id);
+                listener.onViewAccount(accountId);
             }
         });
     }
@@ -54,7 +54,7 @@ class AccountViewHolder extends RecyclerView.ViewHolder {
         container.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                listener.onViewAccount(id);
+                listener.onViewAccount(accountId);
             }
         });
     }

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusViewHolder.java
@@ -425,8 +425,8 @@ class StatusViewHolder extends RecyclerView.ViewHolder {
         container.setOnClickListener(viewThreadListener);
     }
 
-    void setupWithStatus(Status status, StatusActionListener listener,
-            boolean mediaPreviewEnabled) {
+    void setupWithStatus(Status status, final StatusActionListener listener,
+                         boolean mediaPreviewEnabled) {
         Status realStatus = status.getActionableStatus();
 
         setDisplayName(realStatus.account.getDisplayName());
@@ -474,5 +474,15 @@ class StatusViewHolder extends RecyclerView.ViewHolder {
         } else {
             setSpoilerText(realStatus.spoilerText);
         }
+
+        // I think it's not efficient to create new object every time we bind a holder.
+        // More efficient approach would be creating View.OnClickListener during holder creation
+        // and storing StatusActionListener in a variable after binding.
+        rebloggedBar.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                listener.onOpenReblog(getAdapterPosition());
+            }
+        });
     }
 }

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
@@ -226,6 +226,12 @@ public class NotificationsFragment extends SFragment implements
     }
 
     @Override
+    public void onOpenReblog(int position) {
+        Notification notification = adapter.getItem(position);
+        if (notification != null) onViewAccount(notification.account.id);
+    }
+
+    @Override
     public void onViewTag(String tag) {
         super.viewTag(tag);
     }

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/SFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/SFragment.java
@@ -169,6 +169,11 @@ public abstract class SFragment extends BaseFragment {
         callList.add(call);
     }
 
+    protected void openReblog(@Nullable final Status status) {
+        if (status == null) return;
+        viewAccount(status.account.id);
+    }
+
     private void mute(String id) {
         Call<Relationship> call = mastodonApi.muteAccount(id);
         call.enqueue(new Callback<Relationship>() {

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/TimelineFragment.java
@@ -247,6 +247,11 @@ public class TimelineFragment extends SFragment implements
     }
 
     @Override
+    public void onOpenReblog(int position) {
+        super.openReblog(adapter.getItem(position));
+    }
+
+    @Override
     public void onViewMedia(String[] urls, int urlIndex, Status.MediaAttachment.Type type) {
         super.viewMedia(urls, urlIndex, type);
     }

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/ViewThreadFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/ViewThreadFragment.java
@@ -159,6 +159,12 @@ public class ViewThreadFragment extends SFragment implements
     }
 
     @Override
+    public void onOpenReblog(int position) {
+        // there should be no reblogs in the thread but let's implement it to be sure
+        super.openReblog(adapter.getItem(position));
+    }
+
+    @Override
     public void onViewTag(String tag) {
         super.viewTag(tag);
     }

--- a/app/src/main/java/com/keylesspalace/tusky/interfaces/StatusActionListener.java
+++ b/app/src/main/java/com/keylesspalace/tusky/interfaces/StatusActionListener.java
@@ -26,4 +26,5 @@ public interface StatusActionListener extends LinkListener {
     void onMore(View view, final int position);
     void onViewMedia(String[] urls, int index, Status.MediaAttachment.Type type);
     void onViewThread(int position);
+    void onOpenReblog(int position);
 }


### PR DESCRIPTION
Since tapping on a status opens original (not boosted) status, it is impossible to jump to the user who booster the status. So, now clicking on a boost line opens account.
I also renamed "id" in AccountViewHolder because it confused me at first. Hope you don't mind that I left it in this commit.