### PR TITLE
Fix bug with paired list incorrectly adding to the specified position.

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/util/PairedList.java
+++ b/app/src/main/java/com/keylesspalace/tusky/util/PairedList.java
@@ -68,7 +68,7 @@ public final class PairedList<T, V> extends AbstractList<T> {
     @Override
     public void add(int index, T element) {
         synced.add(index, mapper.apply(element));
-        main.add(element);
+        main.add(index, element);
     }
 
     @Override


### PR DESCRIPTION
This bug led to incorrect refreshing of the timeline.