### PR TITLE
fix permission problem when downloading image

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="18" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.VIBRATE" /> <!--For notifications-->
     <uses-permission android:name="android.permission.WAKE_LOCK" />  <!--Required by Eclipse Paho-->
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" /> <!--Required by Eclipse Paho-->

--- a/app/src/main/java/com/keylesspalace/tusky/ViewMediaActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/ViewMediaActivity.java
@@ -201,7 +201,7 @@ public class ViewMediaActivity extends BaseActivity implements ViewMediaFragment
     }
 
     private void downloadImage() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN &&
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
                 ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)
                         != PackageManager.PERMISSION_GRANTED) {
             ActivityCompat.requestPermissions(this,


### PR DESCRIPTION
fixes https://github.com/Vavassor/Tusky/issues/347

tested on my Android 5 & Android 7 devices

**ATTENTION this introduces a new permission in the manifest**

I just wonder... why did nobody check if the download code actually works? You can't request a permission that does not exist in the manifest...