### PR TITLE
Fix extra autocompletion requests

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/util/MentionTokenizer.java
+++ b/app/src/main/java/com/keylesspalace/tusky/util/MentionTokenizer.java
@@ -25,6 +25,7 @@ public class MentionTokenizer implements MultiAutoCompleteTextView.Tokenizer {
     public int findTokenStart(CharSequence text, int cursor) {
         int i = cursor;
         while (i > 0 && text.charAt(i - 1) != '@') {
+            if (!Character.isLetterOrDigit(text.charAt(i - 1))) return cursor;
             i--;
         }
         if (i < 1 || text.charAt(i - 1) != '@') {


### PR DESCRIPTION
The problem was that Tusky kept sending requests for autocompletion while writing toots even when the user wasn't typing a username anymore. As it happened very often we would exceed the API request limit and user wouldn't be able to send the toot.
    
This happened because Tokenizer is not used as expected. In fact, during testing, findTokenEnd() and terminateToken() were never called. I've tried setting a Validator but it wasn't used either. I'm not sure what is the reason.
    
I am afraid it still may work incorrectly for the full nicknames (ones with the instance name, like@name@isntance) because the search may happen for the instance name but it's not as critical.