### PR TITLE
Use Google's maven repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
@@ -11,9 +12,9 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
         maven { url "https://jitpack.io" }
-        maven { url 'https://maven.google.com' }
     }
 }
 


### PR DESCRIPTION
`com.android.tools.build:gradle:3.0.0` is not available on jcenter.

now Google's Maven repository is officially recommended.

ref: https://developer.android.com/studio/build/dependencies.html#google-maven