### PR TITLE
Make placeholder abstraction cleaner

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/adapter/NotificationsAdapter.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/NotificationsAdapter.java
@@ -113,7 +113,7 @@ public class NotificationsAdapter extends RecyclerView.Adapter {
             switch (type) {
                 case MENTION: {
                     StatusViewHolder holder = (StatusViewHolder) viewHolder;
-                    StatusViewData status = concreteNotificaton.getStatusViewData();
+                    StatusViewData.Concrete status = concreteNotificaton.getStatusViewData();
                     holder.setupWithStatus(status,
                             statusListener, mediaPreviewEnabled);
                     break;
@@ -279,7 +279,8 @@ public class NotificationsAdapter extends RecyclerView.Adapter {
             notificationAvatar.setColorFilter(darkerFilter, PorterDuff.Mode.MULTIPLY);
         }
 
-        void setMessage(Notification.Type type, String displayName, StatusViewData status) {
+        void setMessage(Notification.Type type, String displayName,
+                        StatusViewData.Concrete status) {
             Context context = message.getContext();
             String format;
             switch (type) {

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusBaseViewHolder.java
@@ -473,7 +473,7 @@ class StatusBaseViewHolder extends RecyclerView.ViewHolder {
         container.setOnClickListener(viewThreadListener);
     }
 
-    void setupWithStatus(StatusViewData status, final StatusActionListener listener,
+    void setupWithStatus(StatusViewData.Concrete status, final StatusActionListener listener,
                          boolean mediaPreviewEnabled) {
         setDisplayName(status.getUserFullName());
         setUsername(status.getNickname());

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusDetailedViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusDetailedViewHolder.java
@@ -85,7 +85,7 @@ class StatusDetailedViewHolder extends StatusBaseViewHolder {
     }
 
     @Override
-    void setupWithStatus(final StatusViewData status, final StatusActionListener listener,
+    void setupWithStatus(final StatusViewData.Concrete status, final StatusActionListener listener,
                          boolean mediaPreviewEnabled) {
         super.setupWithStatus(status, listener, mediaPreviewEnabled);
         reblogs.setText(status.getReblogsCount());

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/StatusViewHolder.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/StatusViewHolder.java
@@ -67,7 +67,7 @@ public class StatusViewHolder extends StatusBaseViewHolder {
     }
 
     @Override
-    void setupWithStatus(StatusViewData status, final StatusActionListener listener,
+    void setupWithStatus(StatusViewData.Concrete status, final StatusActionListener listener,
                          boolean mediaPreviewEnabled) {
         super.setupWithStatus(status, listener, mediaPreviewEnabled);
 

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/ThreadAdapter.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/ThreadAdapter.java
@@ -33,7 +33,7 @@ public class ThreadAdapter extends RecyclerView.Adapter {
     private static final int VIEW_TYPE_STATUS = 0;
     private static final int VIEW_TYPE_STATUS_DETAILED = 1;
 
-    private List<StatusViewData> statuses;
+    private List<StatusViewData.Concrete> statuses;
     private StatusActionListener statusActionListener;
     private boolean mediaPreviewEnabled;
     private int detailedStatusPosition;
@@ -66,13 +66,12 @@ public class ThreadAdapter extends RecyclerView.Adapter {
 
     @Override
     public void onBindViewHolder(RecyclerView.ViewHolder viewHolder, int position) {
+        StatusViewData.Concrete status = statuses.get(position);
         if (position == detailedStatusPosition) {
             StatusDetailedViewHolder holder = (StatusDetailedViewHolder) viewHolder;
-            StatusViewData status = statuses.get(position);
             holder.setupWithStatus(status, statusActionListener, mediaPreviewEnabled);
         } else {
             StatusViewHolder holder = (StatusViewHolder) viewHolder;
-            StatusViewData status = statuses.get(position);
             holder.setupWithStatus(status, statusActionListener, mediaPreviewEnabled);
         }
     }
@@ -91,13 +90,13 @@ public class ThreadAdapter extends RecyclerView.Adapter {
         return statuses.size();
     }
 
-    public void setStatuses(List<StatusViewData> statuses) {
+    public void setStatuses(List<StatusViewData.Concrete> statuses) {
         this.statuses.clear();
         this.statuses.addAll(statuses);
         notifyDataSetChanged();
     }
 
-    public void addItem(int position, StatusViewData statusViewData) {
+    public void addItem(int position, StatusViewData.Concrete statusViewData) {
         statuses.add(position, statusViewData);
         notifyItemInserted(position);
     }
@@ -109,12 +108,12 @@ public class ThreadAdapter extends RecyclerView.Adapter {
         notifyItemRangeRemoved(0, oldSize);
     }
 
-    public void addAll(int position, List<StatusViewData> statuses) {
+    public void addAll(int position, List<StatusViewData.Concrete> statuses) {
         this.statuses.addAll(position, statuses);
         notifyItemRangeInserted(position, statuses.size());
     }
 
-    public void addAll(List<StatusViewData> statuses) {
+    public void addAll(List<StatusViewData.Concrete> statuses) {
         int end = statuses.size();
         this.statuses.addAll(statuses);
         notifyItemRangeInserted(end, statuses.size());
@@ -126,7 +125,7 @@ public class ThreadAdapter extends RecyclerView.Adapter {
         notifyDataSetChanged();
     }
 
-    public void setItem(int position, StatusViewData status, boolean notifyAdapter) {
+    public void setItem(int position, StatusViewData.Concrete status, boolean notifyAdapter) {
         statuses.set(position, status);
         if (notifyAdapter) {
             notifyItemChanged(position);
@@ -134,7 +133,7 @@ public class ThreadAdapter extends RecyclerView.Adapter {
     }
 
     @Nullable
-    public StatusViewData getItem(int position) {
+    public StatusViewData.Concrete getItem(int position) {
         if (position != RecyclerView.NO_POSITION && position >= 0 && position < statuses.size()) {
             return statuses.get(position);
         } else {

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/TimelineAdapter.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/TimelineAdapter.java
@@ -72,12 +72,14 @@ public class TimelineAdapter extends RecyclerView.Adapter {
     public void onBindViewHolder(RecyclerView.ViewHolder viewHolder, int position) {
         if (position < statuses.size()) {
             StatusViewData status = statuses.get(position);
-            if(status.isPlaceholder()) {
+            if (status instanceof StatusViewData.Placeholder) {
                 PlaceholderViewHolder holder = (PlaceholderViewHolder) viewHolder;
-                holder.setup(!status.isPlaceholderLoading(), statusListener);
+                holder.setup(!((StatusViewData.Placeholder) status).isLoading(), statusListener);
             } else {
+
                 StatusViewHolder holder = (StatusViewHolder) viewHolder;
-                holder.setupWithStatus(status, statusListener, mediaPreviewEnabled);
+                holder.setupWithStatus((StatusViewData.Concrete) status,
+                        statusListener, mediaPreviewEnabled);
             }
 
         } else {
@@ -96,7 +98,7 @@ public class TimelineAdapter extends RecyclerView.Adapter {
         if (position == statuses.size()) {
             return VIEW_TYPE_FOOTER;
         } else {
-            if(statuses.get(position).isPlaceholder()) {
+            if (statuses.get(position) instanceof StatusViewData.Placeholder) {
                 return VIEW_TYPE_PLACEHOLDER;
             } else {
                 return VIEW_TYPE_STATUS;

--- a/app/src/main/java/com/keylesspalace/tusky/entity/Notification.java
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/Notification.java
@@ -27,7 +27,6 @@ public class Notification {
         FAVOURITE,
         @SerializedName("follow")
         FOLLOW,
-        PLACEHOLDER
     }
 
     public Type type;

--- a/app/src/main/java/com/keylesspalace/tusky/entity/Status.java
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/Status.java
@@ -27,10 +27,6 @@ import java.util.Date;
 import java.util.List;
 
 public class Status {
-    /*if placeholder == true, this is not a real status, but a placeholder "load more"
-    and the id represents the max_id for the request*/
-    public boolean placeholder;
-
     public String url;
 
     @SerializedName("reblogs_count")
@@ -115,16 +111,12 @@ public class Status {
         if (o == null || getClass() != o.getClass()) return false;
 
         Status status = (Status) o;
-
-        if (placeholder != status.placeholder) return false;
         return id != null ? id.equals(status.id) : status.id == null;
     }
 
     @Override
     public int hashCode() {
-        int result = (placeholder ? 1 : 0);
-        result = 31 * result + (id != null ? id.hashCode() : 0);
-        return result;
+        return id != null ? id.hashCode() : 0;
     }
 
     public static class MediaAttachment {

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
@@ -44,6 +44,8 @@ import com.keylesspalace.tusky.entity.Status;
 import com.keylesspalace.tusky.interfaces.ActionButtonActivity;
 import com.keylesspalace.tusky.interfaces.StatusActionListener;
 import com.keylesspalace.tusky.receiver.TimelineReceiver;
+import com.keylesspalace.tusky.util.CollectionUtil;
+import com.keylesspalace.tusky.util.Either;
 import com.keylesspalace.tusky.util.HttpHeaderLink;
 import com.keylesspalace.tusky.util.ListUtils;
 import com.keylesspalace.tusky.util.PairedList;
@@ -74,6 +76,21 @@ public class NotificationsFragment extends SFragment implements
         MIDDLE
     }
 
+    /**
+     * Placeholder for the notifications. Consider moving to the separate class to hide constructor
+     * and reuse in different places as needed.
+     */
+    private static final class Placeholder {
+        private static final Placeholder INSTANCE = new Placeholder();
+
+        public static Placeholder getInstance() {
+            return INSTANCE;
+        }
+
+        private Placeholder() {
+        }
+    }
+
     private SwipeRefreshLayout swipeRefreshLayout;
     private LinearLayoutManager layoutManager;
     private RecyclerView recyclerView;
@@ -89,11 +106,17 @@ public class NotificationsFragment extends SFragment implements
     private String bottomId;
     private String topId;
 
-    private final PairedList<Notification, NotificationViewData> notifications
-            = new PairedList<>(new Function<Notification, NotificationViewData>() {
+    // Each element is either a Notification for loading data or a Placeholder
+    private final PairedList<Either<Placeholder, Notification>, NotificationViewData> notifications
+            = new PairedList<>(new Function<Either<Placeholder, Notification>, NotificationViewData>() {
         @Override
-        public NotificationViewData apply(Notification input) {
-            return ViewDataUtils.notificationToViewData(input);
+        public NotificationViewData apply(Either<Placeholder, Notification> input) {
+            if (input.isRight()) {
+                Notification notification = input.getAsRight();
+                return ViewDataUtils.notificationToViewData(notification);
+            } else {
+                return new NotificationViewData.Placeholder(false);
+            }
         }
     });
 
@@ -185,7 +208,7 @@ public class NotificationsFragment extends SFragment implements
                 ActionButtonActivity activity = (ActionButtonActivity) getActivity();
                 FloatingActionButton composeButton = activity.getActionButton();
 
-                if(composeButton != null) {
+                if (composeButton != null) {
                     if (hideFab) {
                         if (dy > 0 && composeButton.isShown()) {
                             composeButton.hide(); // hides the button if we're scrolling down
@@ -225,13 +248,12 @@ public class NotificationsFragment extends SFragment implements
 
     @Override
     public void onReply(int position) {
-        Notification notification = notifications.get(position);
-        super.reply(notification.status);
+        super.reply(notifications.get(position).getAsRight().status);
     }
 
     @Override
     public void onReblog(final boolean reblog, final int position) {
-        final Notification notification = notifications.get(position);
+        final Notification notification = notifications.get(position).getAsRight();
         final Status status = notification.status;
         reblogWithCallback(status, reblog, new Callback<Status>() {
             @Override
@@ -242,7 +264,9 @@ public class NotificationsFragment extends SFragment implements
                     if (status.reblog != null) {
                         status.reblog.reblogged = reblog;
                     }
-                    notifications.set(position, notification);
+                    // Java's type inference *eyeroll*
+                    notifications.set(position,
+                            Either.<Placeholder, Notification>right(notification));
 
                     adapter.updateItemWithNotify(position, notifications.getPairedItem(position), true);
 
@@ -260,7 +284,7 @@ public class NotificationsFragment extends SFragment implements
 
     @Override
     public void onFavourite(final boolean favourite, final int position) {
-        final Notification notification = notifications.get(position);
+        final Notification notification = notifications.get(position).getAsRight();
         final Status status = notification.status;
         favouriteWithCallback(status, favourite, new Callback<Status>() {
             @Override
@@ -272,7 +296,8 @@ public class NotificationsFragment extends SFragment implements
                         status.reblog.favourited = favourite;
                     }
 
-                    notifications.set(position, notification);
+                    notifications.set(position,
+                            Either.<Placeholder, Notification>right(notification));
 
                     adapter.updateItemWithNotify(position, notifications.getPairedItem(position), true);
 
@@ -289,7 +314,7 @@ public class NotificationsFragment extends SFragment implements
 
     @Override
     public void onMore(View view, int position) {
-        Notification notification = notifications.get(position);
+        Notification notification = notifications.get(position).getAsRight();
         super.more(notification.status, view, position);
     }
 
@@ -301,38 +326,40 @@ public class NotificationsFragment extends SFragment implements
 
     @Override
     public void onViewThread(int position) {
-        Notification notification = notifications.get(position);
+        Notification notification = notifications.get(position).getAsRight();
         super.viewThread(notification.status);
     }
 
     @Override
     public void onOpenReblog(int position) {
-        Notification notification = notifications.get(position);
-        if (notification != null) onViewAccount(notification.account.id);
+        Notification notification = notifications.get(position).getAsRight();
+        onViewAccount(notification.account.id);
     }
 
     @Override
     public void onExpandedChange(boolean expanded, int position) {
-        NotificationViewData old = notifications.getPairedItem(position);
+        NotificationViewData.Concrete old =
+                (NotificationViewData.Concrete) notifications.getPairedItem(position);
         StatusViewData statusViewData =
                 new StatusViewData.Builder(old.getStatusViewData())
                         .setIsExpanded(expanded)
                         .createStatusViewData();
-        NotificationViewData notificationViewData = new NotificationViewData(old.getType(),
-                old.getId(), old.getAccount(), statusViewData, false);
+        NotificationViewData notificationViewData = new NotificationViewData.Concrete(old.getType(),
+                old.getId(), old.getAccount(), statusViewData);
         notifications.setPairedItem(position, notificationViewData);
         adapter.updateItemWithNotify(position, notificationViewData, false);
     }
 
     @Override
     public void onContentHiddenChange(boolean isShowing, int position) {
-        NotificationViewData old = notifications.getPairedItem(position);
+        NotificationViewData.Concrete old =
+                (NotificationViewData.Concrete) notifications.getPairedItem(position);
         StatusViewData statusViewData =
                 new StatusViewData.Builder(old.getStatusViewData())
                         .setIsShowingSensitiveContent(isShowing)
                         .createStatusViewData();
-        NotificationViewData notificationViewData = new NotificationViewData(old.getType(),
-                old.getId(), old.getAccount(), statusViewData, false);
+        NotificationViewData notificationViewData = new NotificationViewData.Concrete(old.getType(),
+                old.getId(), old.getAccount(), statusViewData);
         notifications.setPairedItem(position, notificationViewData);
         adapter.updateItemWithNotify(position, notificationViewData, false);
     }
@@ -341,13 +368,12 @@ public class NotificationsFragment extends SFragment implements
     public void onLoadMore(int position) {
         //check bounds before accessing list,
         if (notifications.size() >= position && position > 0) {
-            String fromId = notifications.get(position - 1).id;
-            String toId = notifications.get(position + 1).id;
+            // is it safe?
+            String fromId = notifications.get(position - 1).getAsRight().id;
+            String toId = notifications.get(position + 1).getAsRight().id;
             sendFetchNotificationsRequest(fromId, toId, FetchEnd.MIDDLE, position);
-
-            NotificationViewData old = notifications.getPairedItem(position);
-            NotificationViewData notificationViewData = new NotificationViewData(old.getType(),
-                    old.getId(), old.getAccount(), old.getStatusViewData(), true);
+            NotificationViewData notificationViewData =
+                    new NotificationViewData.Placeholder(true);
             notifications.setPairedItem(position, notificationViewData);
             adapter.updateItemWithNotify(position, notificationViewData, false);
         } else {
@@ -390,10 +416,11 @@ public class NotificationsFragment extends SFragment implements
     @Override
     public void removeAllByAccountId(String accountId) {
         // using iterator to safely remove items while iterating
-        Iterator<Notification> iterator = notifications.iterator();
+        Iterator<Either<Placeholder, Notification>> iterator = notifications.iterator();
         while (iterator.hasNext()) {
-            Notification notification = iterator.next();
-            if (notification.account.id.equals(accountId)) {
+            Either<Placeholder, Notification> notification = iterator.next();
+            Notification maybeNotification = notification.getAsRightOrNull();
+            if (maybeNotification != null && maybeNotification.account.id.equals(accountId)) {
                 iterator.remove();
             }
         }
@@ -470,7 +497,7 @@ public class NotificationsFragment extends SFragment implements
                 break;
             }
             case MIDDLE: {
-                insert(notifications, pos);
+                replacePlaceholderWithNotifications(notifications, pos);
                 break;
             }
             case BOTTOM: {
@@ -520,24 +547,25 @@ public class NotificationsFragment extends SFragment implements
         if (uptoId != null) {
             topId = uptoId;
         }
+        List<Either<Placeholder, Notification>> liftedNew =
+                liftNotificationList(newNotifications);
         if (notifications.isEmpty()) {
-            notifications.addAll(newNotifications);
+            notifications.addAll(liftedNew);
         } else {
-            int index = notifications.indexOf(newNotifications.get(newNotifications.size() - 1));
+            int index = notifications.indexOf(liftedNew.get(newNotifications.size() - 1));
             for (int i = 0; i < index; i++) {
                 notifications.remove(0);
             }
-            int newIndex = newNotifications.indexOf(notifications.get(0));
+
+
+            int newIndex = liftedNew.indexOf(notifications.get(0));
             if (newIndex == -1) {
-                if(index == -1 && newNotifications.size() >= LOAD_AT_ONCE) {
-                    Notification placeholder = new Notification();
-                    placeholder.type = Notification.Type.PLACEHOLDER;
-                    newNotifications.add(placeholder);
+                if (index == -1 && liftedNew.size() >= LOAD_AT_ONCE) {
+                    liftedNew.add(Either.<Placeholder, Notification>left(Placeholder.getInstance()));
                 }
-                notifications.addAll(0, newNotifications);
+                notifications.addAll(0, liftedNew);
             } else {
-                List<Notification> sublist = newNotifications.subList(0, newIndex);
-                notifications.addAll(0, sublist);
+                notifications.addAll(0, liftedNew.subList(0, newIndex));
             }
         }
         adapter.update(notifications.getPairedCopy());
@@ -551,9 +579,10 @@ public class NotificationsFragment extends SFragment implements
             bottomId = fromId;
         }
         int end = notifications.size();
-        Notification last = notifications.get(end - 1);
-        if (last != null && !findNotification(newNotifications, last.id)) {
-            notifications.addAll(newNotifications);
+        List<Either<Placeholder, Notification>> liftedNew = liftNotificationList(newNotifications);
+        Either<Placeholder, Notification> last = notifications.get(end - 1);
+        if (last != null && liftedNew.indexOf(last) == -1) {
+            notifications.addAll(liftedNew);
             List<NotificationViewData> newViewDatas = notifications.getPairedCopy()
                     .subList(notifications.size() - newNotifications.size(),
                             notifications.size());
@@ -561,23 +590,14 @@ public class NotificationsFragment extends SFragment implements
         }
     }
 
-    private static boolean findNotification(List<Notification> notifications, String id) {
-        for (Notification notification : notifications) {
-            if (notification.id.equals(id)) {
-                return true;
-            }
-        }
-        return false;
-    }
 
     private void onFetchNotificationsFailure(Exception exception, FetchEnd fetchEnd, int position) {
         swipeRefreshLayout.setRefreshing(false);
-        if(fetchEnd == FetchEnd.MIDDLE && notifications.getPairedItem(position).getType() == Notification.Type.PLACEHOLDER) {
-            NotificationViewData old = notifications.getPairedItem(position);
-            NotificationViewData notificationViewData = new NotificationViewData(old.getType(),
-                    old.getId(), old.getAccount(), old.getStatusViewData(), false);
-            notifications.setPairedItem(position, notificationViewData);
-            adapter.updateItemWithNotify(position, notificationViewData, true);
+        if (fetchEnd == FetchEnd.MIDDLE && !notifications.get(position).isRight()) {
+            NotificationViewData placeholderVD =
+                    new NotificationViewData.Placeholder(false);
+            notifications.setPairedItem(position, placeholderVD);
+            adapter.updateItemWithNotify(position, placeholderVD, true);
         }
         Log.e(TAG, "Fetch failure: " + exception.getMessage());
         fulfillAnyQueuedFetches(fetchEnd);
@@ -604,8 +624,8 @@ public class NotificationsFragment extends SFragment implements
         }
     }
 
-    private void insert(List<Notification> newNotifications, int pos) {
-
+    private void replacePlaceholderWithNotifications(List<Notification> newNotifications, int pos) {
+        // Remove placeholder
         notifications.remove(pos);
 
         if (ListUtils.isEmpty(newNotifications)) {
@@ -613,15 +633,29 @@ public class NotificationsFragment extends SFragment implements
             return;
         }
 
-        if(newNotifications.size() >= LOAD_AT_ONCE) {
-            Notification placeholder = new Notification();
-            placeholder.type = Notification.Type.PLACEHOLDER;
-            newNotifications.add(placeholder);
+        List<Either<Placeholder, Notification>> liftedNew = liftNotificationList(newNotifications);
+
+        // If we fetched less posts than in the limit, it means that the hole is not filled
+        // If we fetched at least as much it means that there are more posts to load and we should
+        // insert new placeholder
+        if (newNotifications.size() >= LOAD_AT_ONCE) {
+            liftedNew.add(Either.<Placeholder, Notification>left(Placeholder.getInstance()));
         }
 
-        notifications.addAll(pos, newNotifications);
+        notifications.addAll(pos, liftedNew);
         adapter.update(notifications.getPairedCopy());
+    }
 
+    private final Function<Notification, Either<Placeholder, Notification>> notificationLifter =
+            new Function<Notification, Either<Placeholder, Notification>>() {
+                @Override
+                public Either<Placeholder, Notification> apply(Notification input) {
+                    return Either.right(input);
+                }
+            };
+
+    private List<Either<Placeholder, Notification>> liftNotificationList(List<Notification> list) {
+        return CollectionUtil.map(list, notificationLifter);
     }
 
     private void fullyRefresh() {

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
@@ -340,7 +340,7 @@ public class NotificationsFragment extends SFragment implements
     public void onExpandedChange(boolean expanded, int position) {
         NotificationViewData.Concrete old =
                 (NotificationViewData.Concrete) notifications.getPairedItem(position);
-        StatusViewData statusViewData =
+        StatusViewData.Concrete statusViewData =
                 new StatusViewData.Builder(old.getStatusViewData())
                         .setIsExpanded(expanded)
                         .createStatusViewData();
@@ -354,7 +354,7 @@ public class NotificationsFragment extends SFragment implements
     public void onContentHiddenChange(boolean isShowing, int position) {
         NotificationViewData.Concrete old =
                 (NotificationViewData.Concrete) notifications.getPairedItem(position);
-        StatusViewData statusViewData =
+        StatusViewData.Concrete statusViewData =
                 new StatusViewData.Builder(old.getStatusViewData())
                         .setIsShowingSensitiveContent(isShowing)
                         .createStatusViewData();
@@ -368,10 +368,13 @@ public class NotificationsFragment extends SFragment implements
     public void onLoadMore(int position) {
         //check bounds before accessing list,
         if (notifications.size() >= position && position > 0) {
-            // is it safe?
-            String fromId = notifications.get(position - 1).getAsRight().id;
-            String toId = notifications.get(position + 1).getAsRight().id;
-            sendFetchNotificationsRequest(fromId, toId, FetchEnd.MIDDLE, position);
+            Notification previous = notifications.get(position - 1).getAsRightOrNull();
+            Notification next = notifications.get(position + 1).getAsRightOrNull();
+            if (previous == null || next == null) {
+                Log.e(TAG, "Failed to load more, invalid placeholder position: " + position);
+                return;
+            }
+            sendFetchNotificationsRequest(previous.id, next.id, FetchEnd.MIDDLE, position);
             NotificationViewData notificationViewData =
                     new NotificationViewData.Placeholder(true);
             notifications.setPairedItem(position, notificationViewData);

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/ViewThreadFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/ViewThreadFragment.java
@@ -69,7 +69,7 @@ public class ViewThreadFragment extends SFragment implements
 
     private int statusIndex = 0;
 
-    private final PairedList<Status, StatusViewData> statuses =
+    private final PairedList<Status, StatusViewData.Concrete> statuses =
             new PairedList<>(ViewDataUtils.statusMapper());
 
     public static ViewThreadFragment newInstance(String id) {
@@ -83,7 +83,7 @@ public class ViewThreadFragment extends SFragment implements
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container,
-            @Nullable Bundle savedInstanceState) {
+                             @Nullable Bundle savedInstanceState) {
         View rootView = inflater.inflate(R.layout.fragment_view_thread, container, false);
 
         Context context = getContext();
@@ -227,18 +227,20 @@ public class ViewThreadFragment extends SFragment implements
 
     @Override
     public void onExpandedChange(boolean expanded, int position) {
-        StatusViewData newViewData = new StatusViewData.Builder(statuses.getPairedItem(position))
-                .setIsExpanded(expanded)
-                .createStatusViewData();
+        StatusViewData.Concrete newViewData =
+                new StatusViewData.Builder(statuses.getPairedItem(position))
+                        .setIsExpanded(expanded)
+                        .createStatusViewData();
         statuses.setPairedItem(position, newViewData);
         adapter.setItem(position, newViewData, false);
     }
 
     @Override
     public void onContentHiddenChange(boolean isShowing, int position) {
-        StatusViewData newViewData = new StatusViewData.Builder(statuses.getPairedItem(position))
-                .setIsShowingSensitiveContent(isShowing)
-                .createStatusViewData();
+        StatusViewData.Concrete newViewData =
+                new StatusViewData.Builder(statuses.getPairedItem(position))
+                        .setIsShowingSensitiveContent(isShowing)
+                        .createStatusViewData();
         statuses.setPairedItem(position, newViewData);
         adapter.setItem(position, newViewData, false);
     }
@@ -260,7 +262,7 @@ public class ViewThreadFragment extends SFragment implements
 
     @Override
     public void removeItem(int position) {
-        if(position == statusIndex) {
+        if (position == statusIndex) {
             //the status got removed, close the activity
             getActivity().finish();
         }
@@ -283,7 +285,7 @@ public class ViewThreadFragment extends SFragment implements
             }
         }
         statusIndex = statuses.indexOf(status);
-        if(statusIndex == -1) {
+        if (statusIndex == -1) {
             //the status got removed, close the activity
             getActivity().finish();
             return;
@@ -384,8 +386,8 @@ public class ViewThreadFragment extends SFragment implements
         int i = statusIndex;
         statuses.add(i, status);
         adapter.setDetailedStatusPosition(i);
-        StatusViewData viewData = statuses.getPairedItem(i);
-        if(viewData.getCard() == null && card != null) {
+        StatusViewData.Concrete viewData = statuses.getPairedItem(i);
+        if (viewData.getCard() == null && card != null) {
             viewData = new StatusViewData.Builder(viewData)
                     .setCard(card)
                     .createStatusViewData();
@@ -410,7 +412,7 @@ public class ViewThreadFragment extends SFragment implements
         statusIndex = ancestors.size();
         adapter.setDetailedStatusPosition(statusIndex);
         statuses.addAll(0, ancestors);
-        List<StatusViewData> ancestorsViewDatas = statuses.getPairedCopy().subList(0, statusIndex);
+        List<StatusViewData.Concrete> ancestorsViewDatas = statuses.getPairedCopy().subList(0, statusIndex);
         if (BuildConfig.DEBUG && ancestors.size() != ancestorsViewDatas.size()) {
             String error = String.format(Locale.getDefault(),
                     "Incorrectly got statusViewData sublist." +
@@ -425,8 +427,8 @@ public class ViewThreadFragment extends SFragment implements
             // In case we needed to delete everything (which is way easier than deleting
             // everything except one), re-insert the remaining status here.
             statuses.add(statusIndex, mainStatus);
-            StatusViewData viewData = statuses.getPairedItem(statusIndex);
-            if(viewData.getCard() == null && card != null) {
+            StatusViewData.Concrete viewData = statuses.getPairedItem(statusIndex);
+            if (viewData.getCard() == null && card != null) {
                 viewData = new StatusViewData.Builder(viewData)
                         .setCard(card)
                         .createStatusViewData();
@@ -436,9 +438,9 @@ public class ViewThreadFragment extends SFragment implements
 
         // Insert newly fetched descendants
         statuses.addAll(descendants);
-        List<StatusViewData> descendantsViewData;
-            descendantsViewData = statuses.getPairedCopy()
-                    .subList(statuses.size() - descendants.size(), statuses.size());
+        List<StatusViewData.Concrete> descendantsViewData;
+        descendantsViewData = statuses.getPairedCopy()
+                .subList(statuses.size() - descendants.size(), statuses.size());
         if (BuildConfig.DEBUG && descendants.size() != descendantsViewData.size()) {
             String error = String.format(Locale.getDefault(),
                     "Incorrectly got statusViewData sublist." +
@@ -452,16 +454,14 @@ public class ViewThreadFragment extends SFragment implements
 
     private void showCard(Card card) {
         this.card = card;
-        if(statuses.size() != 0) {
-            StatusViewData oldViewData = statuses.getPairedItem(statusIndex);
-                    if(oldViewData != null) {
-                        StatusViewData newViewData = new StatusViewData.Builder(statuses.getPairedItem(statusIndex))
-                                .setCard(card)
-                                .createStatusViewData();
+        if (statuses.size() != 0) {
+            StatusViewData.Concrete newViewData =
+                    new StatusViewData.Builder(statuses.getPairedItem(statusIndex))
+                            .setCard(card)
+                            .createStatusViewData();
 
-                        statuses.setPairedItem(statusIndex, newViewData);
-                        adapter.setItem(statusIndex, newViewData, true);
-                    }
+            statuses.setPairedItem(statusIndex, newViewData);
+            adapter.setItem(statusIndex, newViewData, true);
         }
     }
 

--- a/app/src/main/java/com/keylesspalace/tusky/util/CollectionUtil.java
+++ b/app/src/main/java/com/keylesspalace/tusky/util/CollectionUtil.java
@@ -1,0 +1,38 @@
+/* Copyright 2017 Andrew Dawson
+ *
+ * This file is a part of Tusky.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Tusky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Tusky; if not,
+ * see <http://www.gnu.org/licenses>. */
+package com.keylesspalace.tusky.util;
+
+import android.arch.core.util.Function;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by charlag on 05/11/17.
+ */
+
+public final class CollectionUtil {
+    private CollectionUtil() {
+        throw new AssertionError();
+    }
+
+    public static <E, R> List<R> map(List<E> list, Function<E, R> mapper) {
+        final List<R> newList = new ArrayList<>(list.size());
+        for (E el : list) {
+            newList.add(mapper.apply(el));
+        }
+        return newList;
+    }
+}

--- a/app/src/main/java/com/keylesspalace/tusky/util/Either.java
+++ b/app/src/main/java/com/keylesspalace/tusky/util/Either.java
@@ -1,0 +1,125 @@
+/* Copyright 2017 Andrew Dawson
+ *
+ * This file is a part of Tusky.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Tusky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Tusky; if not,
+ * see <http://www.gnu.org/licenses>. */
+package com.keylesspalace.tusky.util;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+/**
+ * Created by charlag on 05/11/17.
+ *
+ * Class to represent sum type/tagged union/variant/ADT e.t.c.
+ * It is either Left or Right.
+ */
+public final class Either<L, R> {
+
+    /**
+     * Constructs Left instance of either
+     * @param left Object to be considered Left
+     * @param <L> Left type
+     * @param <R> Right type
+     * @return new instance of Either which contains left.
+     */
+    public static <L, R> Either<L, R> left(L left) {
+        return new Either<>(left, false);
+    }
+
+    /**
+     * Constructs Right instance of either
+     * @param right Object to be considered Right
+     * @param <L> Left type
+     * @param <R> Right type
+     * @return new instance of Either which contains right.
+     */
+    public static <L, R> Either<L, R> right(R right) {
+        return new Either<>(right, true);
+    }
+
+    private final Object value;
+    // we need it because of the types erasure
+    private boolean isRight;
+
+    private Either(Object value, boolean isRight) {
+        this.value = value;
+        this.isRight = isRight;
+    }
+
+    public boolean isRight() {
+        return isRight;
+    }
+
+    /**
+     * Try to get contained object as a Left or throw an exception.
+     * @throws AssertionError If contained value is Right
+     * @return contained value as Right
+     */
+    public @NonNull L getAsLeft() {
+        if (isRight) {
+            throw new AssertionError("Tried to get the Either as Left while it is Right");
+        }
+        //noinspection unchecked
+        return (L) value;
+    }
+
+    /**
+     * Try to get contained object as a Right or throw an exception.
+     * @throws AssertionError If contained value is Left
+     * @return contained value as Right
+     */
+    public @NonNull R getAsRight() {
+        if (!isRight) {
+            throw new AssertionError("Tried to get the Either as Right while it is Left");
+        }
+        //noinspection unchecked
+        return (R) value;
+    }
+
+    /**
+     * Same as {@link #getAsLeft()} but returns {@code null} is the value if Right instead of
+     * throwing an exception.
+     * @return contained value as Left or null
+     */
+    public @Nullable L getAsLeftOrNull() {
+        if (isRight) {
+            return null;
+        }
+        //noinspection unchecked
+        return (L) value;
+    }
+
+    /**
+     * Same as {@link #getAsRightOrNull()} but returns {@code null} is the value if Left instead of
+     * throwing an exception.
+     * @return contained value as Right or null
+     */
+    public @Nullable R getAsRightOrNull() {
+        if (!isRight) {
+            return null;
+        }
+        //noinspection unchecked
+        return (R) value;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null) return false;
+        if (!(obj instanceof Either)) return false;
+        Either that = (Either) obj;
+        return this.isRight == that.isRight &&
+                (this.value == that.value ||
+                        this.value != null && this.value.equals(that.value));
+    }
+}

--- a/app/src/main/java/com/keylesspalace/tusky/util/ViewDataUtils.java
+++ b/app/src/main/java/com/keylesspalace/tusky/util/ViewDataUtils.java
@@ -34,7 +34,7 @@ public final class ViewDataUtils {
     @Nullable
     public static StatusViewData statusToViewData(@Nullable Status status) {
         if (status == null) return null;
-        if(status.placeholder) {
+        if (status.placeholder) {
             return new StatusViewData.Builder().setId(status.id)
                     .setPlaceholder(true)
                     .createStatusViewData();
@@ -80,8 +80,8 @@ public final class ViewDataUtils {
     }
 
     public static NotificationViewData notificationToViewData(Notification notification) {
-        return new NotificationViewData(notification.type, notification.id, notification.account,
-                statusToViewData(notification.status), false);
+        return new NotificationViewData.Concrete(notification.type, notification.id, notification.account,
+                statusToViewData(notification.status));
     }
 
     public static List<NotificationViewData> notificationListToViewDataList(

--- a/app/src/main/java/com/keylesspalace/tusky/util/ViewDataUtils.java
+++ b/app/src/main/java/com/keylesspalace/tusky/util/ViewDataUtils.java
@@ -32,13 +32,8 @@ import java.util.List;
 
 public final class ViewDataUtils {
     @Nullable
-    public static StatusViewData statusToViewData(@Nullable Status status) {
+    public static StatusViewData.Concrete statusToViewData(@Nullable Status status) {
         if (status == null) return null;
-        if (status.placeholder) {
-            return new StatusViewData.Builder().setId(status.id)
-                    .setPlaceholder(true)
-                    .createStatusViewData();
-        }
         Status visibleStatus = status.reblog == null ? status : status.reblog;
         return new StatusViewData.Builder().setId(status.id)
                 .setAttachments(visibleStatus.attachments)
@@ -75,11 +70,11 @@ public final class ViewDataUtils {
         return viewDatas;
     }
 
-    public static Function<Status, StatusViewData> statusMapper() {
+    public static Function<Status, StatusViewData.Concrete> statusMapper() {
         return statusMapper;
     }
 
-    public static NotificationViewData notificationToViewData(Notification notification) {
+    public static NotificationViewData.Concrete notificationToViewData(Notification notification) {
         return new NotificationViewData.Concrete(notification.type, notification.id, notification.account,
                 statusToViewData(notification.status));
     }
@@ -93,10 +88,10 @@ public final class ViewDataUtils {
         return viewDatas;
     }
 
-    private static final Function<Status, StatusViewData> statusMapper =
-            new Function<Status, StatusViewData>() {
+    private static final Function<Status, StatusViewData.Concrete> statusMapper =
+            new Function<Status, StatusViewData.Concrete>() {
                 @Override
-                public StatusViewData apply(Status input) {
+                public StatusViewData.Concrete apply(Status input) {
                     return ViewDataUtils.statusToViewData(input);
                 }
             };

--- a/app/src/main/java/com/keylesspalace/tusky/view/ConversationLineItemDecoration.java
+++ b/app/src/main/java/com/keylesspalace/tusky/view/ConversationLineItemDecoration.java
@@ -49,16 +49,16 @@ public class ConversationLineItemDecoration extends RecyclerView.ItemDecoration 
 
             int position = parent.getChildAdapterPosition(child);
             ThreadAdapter adapter = (ThreadAdapter) parent.getAdapter();
-            StatusViewData current = adapter.getItem(position);
+            StatusViewData.Concrete current = adapter.getItem(position);
             int dividerTop, dividerBottom;
             if (current != null) {
-                StatusViewData above = adapter.getItem(position - 1);
+                StatusViewData.Concrete above = adapter.getItem(position - 1);
                 if (above != null && above.getId().equals(current.getInReplyToId())) {
                     dividerTop = child.getTop();
                 } else {
                     dividerTop = child.getTop() + avatarMargin;
                 }
-                StatusViewData below = adapter.getItem(position + 1);
+                StatusViewData.Concrete below = adapter.getItem(position + 1);
                 if (below != null && current.getId().equals(below.getInReplyToId())) {
                     dividerBottom = child.getBottom();
                 } else {

--- a/app/src/main/java/com/keylesspalace/tusky/viewdata/NotificationViewData.java
+++ b/app/src/main/java/com/keylesspalace/tusky/viewdata/NotificationViewData.java
@@ -20,41 +20,59 @@ import com.keylesspalace.tusky.entity.Notification;
 
 /**
  * Created by charlag on 12/07/2017.
+ *
+ * Class to represent data required to display either a notification or a placeholder.
+ * It is either a {@link Placeholder} or a {@link Concrete}.
+ * It is modelled this way because close relationship between placeholder and concrete notification
+ * is fine in this case. Placeholder case is not modelled as a type of notification because
+ * invariants would be violated and because it would model domain incorrectly. It is prefereable to
+ * {@link com.keylesspalace.tusky.util.Either} because class hierarchy is cheaper, faster and
+ * more native.
  */
-
-public final class NotificationViewData {
-    private final Notification.Type type;
-    private final String id;
-    private final Account account;
-    private final StatusViewData statusViewData;
-    private final boolean placeholderLoading;
-
-    public NotificationViewData(Notification.Type type, String id, Account account,
-                                StatusViewData statusViewData, boolean placeholderLoading) {
-        this.type = type;
-        this.id = id;
-        this.account = account;
-        this.statusViewData = statusViewData;
-        this.placeholderLoading = placeholderLoading;
+public abstract class NotificationViewData {
+    private NotificationViewData() {
     }
 
-    public Notification.Type getType() {
-        return type;
+    public static  final class Concrete extends NotificationViewData {
+        private final Notification.Type type;
+        private final String id;
+        private final Account account;
+        private final StatusViewData statusViewData;
+
+        public Concrete(Notification.Type type, String id, Account account,
+                        StatusViewData statusViewData) {
+            this.type = type;
+            this.id = id;
+            this.account = account;
+            this.statusViewData = statusViewData;
+        }
+
+        public Notification.Type getType() {
+            return type;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public Account getAccount() {
+            return account;
+        }
+
+        public StatusViewData getStatusViewData() {
+            return statusViewData;
+        }
     }
 
-    public String getId() {
-        return id;
-    }
+    public static final class Placeholder extends NotificationViewData {
+        private final boolean isLoading;
 
-    public Account getAccount() {
-        return account;
-    }
+        public Placeholder(boolean isLoading) {
+            this.isLoading = isLoading;
+        }
 
-    public StatusViewData getStatusViewData() {
-        return statusViewData;
-    }
-
-    public boolean isPlaceholderLoading() {
-        return placeholderLoading;
+        public boolean isLoading() {
+            return isLoading;
+        }
     }
 }

--- a/app/src/main/java/com/keylesspalace/tusky/viewdata/NotificationViewData.java
+++ b/app/src/main/java/com/keylesspalace/tusky/viewdata/NotificationViewData.java
@@ -37,10 +37,10 @@ public abstract class NotificationViewData {
         private final Notification.Type type;
         private final String id;
         private final Account account;
-        private final StatusViewData statusViewData;
+        private final StatusViewData.Concrete statusViewData;
 
         public Concrete(Notification.Type type, String id, Account account,
-                        StatusViewData statusViewData) {
+                        StatusViewData.Concrete statusViewData) {
             this.type = type;
             this.id = id;
             this.account = account;
@@ -59,7 +59,7 @@ public abstract class NotificationViewData {
             return account;
         }
 
-        public StatusViewData getStatusViewData() {
+        public StatusViewData.Concrete getStatusViewData() {
             return statusViewData;
         }
     }

--- a/app/src/main/java/com/keylesspalace/tusky/viewdata/StatusViewData.java
+++ b/app/src/main/java/com/keylesspalace/tusky/viewdata/StatusViewData.java
@@ -27,195 +27,202 @@ import java.util.List;
 
 /**
  * Created by charlag on 11/07/2017.
+ *
+ * Class to represent data required to display either a notification or a placeholder.
+ * It is either a {@link StatusViewData.Concrete} or a {@link StatusViewData.Placeholder}.
  */
 
-public final class StatusViewData {
-    private final String id;
-    private final Spanned content;
-    private final boolean reblogged;
-    private final boolean favourited;
-    @Nullable
-    private final String spoilerText;
-    private final Status.Visibility visibility;
-    private final Status.MediaAttachment[] attachments;
-    @Nullable
-    private final String rebloggedByUsername;
-    @Nullable
-    private final String rebloggedAvatar;
-    private final boolean isSensitive;
-    private final boolean isExpanded;
-    private final boolean isShowingSensitiveContent;
-    private final String userFullName;
-    private final String nickname;
-    private final String avatar;
-    private final Date createdAt;
-    private final String reblogsCount;
-    private final String favouritesCount;
-    @Nullable
-    private final String inReplyToId;
-    // I would rather have something else but it would be too much of a rewrite
-    @Nullable
-    private final Status.Mention[] mentions;
-    private final String senderId;
-    private final boolean rebloggingEnabled;
-    private final Status.Application application;
-    private final List<Status.Emoji> emojis;
-    @Nullable
-    private final Card card;
+public abstract class StatusViewData {
 
-    private final boolean placeholder;
-
-    private final boolean placeholderLoading;
-
-    public StatusViewData(String id, Spanned content, boolean reblogged, boolean favourited,
-                          @Nullable String spoilerText, Status.Visibility visibility, Status.MediaAttachment[] attachments,
-                          @Nullable String rebloggedByUsername, @Nullable String rebloggedAvatar, boolean sensitive, boolean isExpanded,
-                          boolean isShowingSensitiveWarning, String userFullName, String nickname, String avatar,
-                          Date createdAt, String reblogsCount, String favouritesCount, @Nullable String inReplyToId,
-                          @Nullable Status.Mention[] mentions, String senderId, boolean rebloggingEnabled,
-                          Status.Application application, List<Status.Emoji> emojis, @Nullable Card card,
-                          boolean placeholder, boolean placeholderLoading) {
-        this.id = id;
-        this.content = content;
-        this.reblogged = reblogged;
-        this.favourited = favourited;
-        this.spoilerText = spoilerText;
-        this.visibility = visibility;
-        this.attachments = attachments;
-        this.rebloggedByUsername = rebloggedByUsername;
-        this.rebloggedAvatar = rebloggedAvatar;
-        this.isSensitive = sensitive;
-        this.isExpanded = isExpanded;
-        this.isShowingSensitiveContent = isShowingSensitiveWarning;
-        this.userFullName = userFullName;
-        this.nickname = nickname;
-        this.avatar = avatar;
-        this.createdAt = createdAt;
-        this.reblogsCount = reblogsCount;
-        this.favouritesCount = favouritesCount;
-        this.inReplyToId = inReplyToId;
-        this.mentions = mentions;
-        this.senderId = senderId;
-        this.rebloggingEnabled = rebloggingEnabled;
-        this.application = application;
-        this.emojis = emojis;
-        this.card = card;
-        this.placeholder = placeholder;
-        this.placeholderLoading = placeholderLoading;
+    private StatusViewData() {
     }
 
-    public String getId() {
-        return id;
+    public static final class Concrete extends StatusViewData {
+        private final String id;
+        private final Spanned content;
+        private final boolean reblogged;
+        private final boolean favourited;
+        @Nullable
+        private final String spoilerText;
+        private final Status.Visibility visibility;
+        private final Status.MediaAttachment[] attachments;
+        @Nullable
+        private final String rebloggedByUsername;
+        @Nullable
+        private final String rebloggedAvatar;
+        private final boolean isSensitive;
+        private final boolean isExpanded;
+        private final boolean isShowingSensitiveContent;
+        private final String userFullName;
+        private final String nickname;
+        private final String avatar;
+        private final Date createdAt;
+        private final String reblogsCount;
+        private final String favouritesCount;
+        @Nullable
+        private final String inReplyToId;
+        // I would rather have something else but it would be too much of a rewrite
+        @Nullable
+        private final Status.Mention[] mentions;
+        private final String senderId;
+        private final boolean rebloggingEnabled;
+        private final Status.Application application;
+        private final List<Status.Emoji> emojis;
+        @Nullable
+        private final Card card;
+
+        public Concrete(String id, Spanned content, boolean reblogged, boolean favourited,
+                        @Nullable String spoilerText, Status.Visibility visibility, Status.MediaAttachment[] attachments,
+                        @Nullable String rebloggedByUsername, @Nullable String rebloggedAvatar, boolean sensitive, boolean isExpanded,
+                        boolean isShowingSensitiveWarning, String userFullName, String nickname, String avatar,
+                        Date createdAt, String reblogsCount, String favouritesCount, @Nullable String inReplyToId,
+                        @Nullable Status.Mention[] mentions, String senderId, boolean rebloggingEnabled,
+                        Status.Application application, List<Status.Emoji> emojis, @Nullable Card card) {
+            this.id = id;
+            this.content = content;
+            this.reblogged = reblogged;
+            this.favourited = favourited;
+            this.spoilerText = spoilerText;
+            this.visibility = visibility;
+            this.attachments = attachments;
+            this.rebloggedByUsername = rebloggedByUsername;
+            this.rebloggedAvatar = rebloggedAvatar;
+            this.isSensitive = sensitive;
+            this.isExpanded = isExpanded;
+            this.isShowingSensitiveContent = isShowingSensitiveWarning;
+            this.userFullName = userFullName;
+            this.nickname = nickname;
+            this.avatar = avatar;
+            this.createdAt = createdAt;
+            this.reblogsCount = reblogsCount;
+            this.favouritesCount = favouritesCount;
+            this.inReplyToId = inReplyToId;
+            this.mentions = mentions;
+            this.senderId = senderId;
+            this.rebloggingEnabled = rebloggingEnabled;
+            this.application = application;
+            this.emojis = emojis;
+            this.card = card;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public Spanned getContent() {
+            return content;
+        }
+
+        public boolean isReblogged() {
+            return reblogged;
+        }
+
+        public boolean isFavourited() {
+            return favourited;
+        }
+
+        @Nullable
+        public String getSpoilerText() {
+            return spoilerText;
+        }
+
+        public Status.Visibility getVisibility() {
+            return visibility;
+        }
+
+        public Status.MediaAttachment[] getAttachments() {
+            return attachments;
+        }
+
+        @Nullable
+        public String getRebloggedByUsername() {
+            return rebloggedByUsername;
+        }
+
+        public boolean isSensitive() {
+            return isSensitive;
+        }
+
+        public boolean isExpanded() {
+            return isExpanded;
+        }
+
+        public boolean isShowingSensitiveContent() {
+            return isShowingSensitiveContent;
+        }
+
+        @Nullable
+        public String getRebloggedAvatar() {
+            return rebloggedAvatar;
+        }
+
+        public String getUserFullName() {
+            return userFullName;
+        }
+
+        public String getNickname() {
+            return nickname;
+        }
+
+        public String getAvatar() {
+            return avatar;
+        }
+
+        public Date getCreatedAt() {
+            return createdAt;
+        }
+
+        public String getReblogsCount() {
+            return reblogsCount;
+        }
+
+        public String getFavouritesCount() {
+            return favouritesCount;
+        }
+
+        @Nullable
+        public String getInReplyToId() {
+            return inReplyToId;
+        }
+
+        public String getSenderId() {
+            return senderId;
+        }
+
+        public Boolean getRebloggingEnabled() {
+            return rebloggingEnabled;
+        }
+
+        @Nullable
+        public Status.Mention[] getMentions() {
+            return mentions;
+        }
+
+        public Status.Application getApplication() {
+            return application;
+        }
+
+        public List<Status.Emoji> getEmojis() {
+            return emojis;
+        }
+
+        @Nullable
+        public Card getCard() {
+            return card;
+        }
+
     }
 
-    public Spanned getContent() {
-        return content;
-    }
+    public static final class Placeholder extends StatusViewData {
+        private final boolean isLoading;
 
-    public boolean isReblogged() {
-        return reblogged;
-    }
+        public Placeholder(boolean isLoading) {
+            this.isLoading = isLoading;
+        }
 
-    public boolean isFavourited() {
-        return favourited;
-    }
-
-    @Nullable
-    public String getSpoilerText() {
-        return spoilerText;
-    }
-
-    public Status.Visibility getVisibility() {
-        return visibility;
-    }
-
-    public Status.MediaAttachment[] getAttachments() {
-        return attachments;
-    }
-
-    @Nullable
-    public String getRebloggedByUsername() {
-        return rebloggedByUsername;
-    }
-
-    public boolean isSensitive() {
-        return isSensitive;
-    }
-
-    public boolean isExpanded() {
-        return isExpanded;
-    }
-
-    public boolean isShowingSensitiveContent() {
-        return isShowingSensitiveContent;
-    }
-
-    @Nullable
-    public String getRebloggedAvatar() {
-        return rebloggedAvatar;
-    }
-
-    public String getUserFullName() {
-        return userFullName;
-    }
-
-    public String getNickname() {
-        return nickname;
-    }
-
-    public String getAvatar() {
-        return avatar;
-    }
-
-    public Date getCreatedAt() {
-        return createdAt;
-    }
-
-    public String getReblogsCount() {
-        return reblogsCount;
-    }
-
-    public String getFavouritesCount() {
-        return favouritesCount;
-    }
-
-    @Nullable
-    public String getInReplyToId() {
-        return inReplyToId;
-    }
-
-    public String getSenderId() {
-        return senderId;
-    }
-
-    public Boolean getRebloggingEnabled() {
-        return rebloggingEnabled;
-    }
-
-    @Nullable
-    public Status.Mention[] getMentions() {
-        return mentions;
-    }
-
-    public Status.Application getApplication() {
-        return application;
-    }
-
-    public List<Status.Emoji> getEmojis() {
-        return emojis;
-    }
-
-    @Nullable
-    public Card getCard() {
-        return card;
-    }
-
-    public boolean isPlaceholder() {
-        return placeholder;
-    }
-
-    public boolean isPlaceholderLoading() {
-        return placeholderLoading;
+        public boolean isLoading() {
+            return isLoading;
+        }
     }
 
     public static class Builder {
@@ -244,13 +251,11 @@ public final class StatusViewData {
         private Status.Application application;
         private List<Status.Emoji> emojis;
         private Card card;
-        private boolean placeholder;
-        private boolean placeholderLoading;
 
         public Builder() {
         }
 
-        public Builder(final StatusViewData viewData) {
+        public Builder(final StatusViewData.Concrete viewData) {
             id = viewData.id;
             content = viewData.content;
             reblogged = viewData.reblogged;
@@ -276,9 +281,6 @@ public final class StatusViewData {
             application = viewData.application;
             emojis = viewData.getEmojis();
             card = viewData.getCard();
-            placeholder = viewData.isPlaceholder();
-            placeholderLoading = viewData.isPlaceholderLoading();
-
         }
 
         public Builder setId(String id) {
@@ -406,25 +408,15 @@ public final class StatusViewData {
             return this;
         }
 
-        public Builder setPlaceholder(boolean placeholder) {
-            this.placeholder = placeholder;
-            return this;
-        }
-
-        public Builder setPlaceholderLoading(boolean placeholderLoading) {
-            this.placeholderLoading = placeholderLoading;
-            return this;
-        }
-
-        public StatusViewData createStatusViewData() {
+        public StatusViewData.Concrete createStatusViewData() {
             if (this.emojis == null) emojis = Collections.emptyList();
             if (this.createdAt == null) createdAt = new Date();
 
-            return new StatusViewData(id, content, reblogged, favourited, spoilerText, visibility,
+            return new StatusViewData.Concrete(id, content, reblogged, favourited, spoilerText, visibility,
                     attachments, rebloggedByUsername, rebloggedAvatar, isSensitive, isExpanded,
                     isShowingSensitiveContent, userFullName, nickname, avatar, createdAt, reblogsCount,
                     favouritesCount, inReplyToId, mentions, senderId, rebloggingEnabled, application,
-                    emojis, card, placeholder, placeholderLoading);
+                    emojis, card);
         }
     }
 }


### PR DESCRIPTION
Okay, this may seem as an overkill but I've made it as clean as I could and it may save us some future headaches - programmer error will crash the app, not fail silently (which I would prefer in most cases).
I did this only for notifications but I would like to do the same for statuses, I just don't have time right now.
I modeled placeholder data using Either because Notification itself shouldn't be concerned about presentation so I think adding Placeholder as a notification type is not the best practice. ```Either``` shouldn't be huge overhead.
```NotificationVIewData``` is modeled using class hierarchy because it is okay for it to know that it may be a placeholder and it is cheaper.
I could implement ```Either``` using class hierarchy too but I just wrote it out of my mind. I am a little bit worried about ```equals()``` but it seems okay.
We could measure how bad is memory overhead and conclude if it is okay to do the same for statuses.
I didn't test it extensively but it seems to work.
I am also worried about one place in ```NotificationsFragment``` (I've left an "is it safe?" comment), I didn't dig into the logic deep enough, can you verify it please?
Thank you, once again, awesome work on logic (which is usually very hard for me) and I would like to help you clean it up a little now.