### PR TITLE
Status notifications behavior (closes #322, partly #292)

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/NotificationsFragment.java
@@ -395,6 +395,18 @@ public class NotificationsFragment extends SFragment implements
     }
 
     @Override
+    public void onViewStatusForNotificationId(String notificationId) {
+        for (Either<Placeholder, Notification> either : notifications) {
+            Notification notification = either.getAsRightOrNull();
+            if (notification != null && notification.id.equals(notificationId)) {
+                super.viewThread(notification.status);
+                return;
+            }
+        }
+        Log.w(TAG, "Didn't find a notification for ID: " + notificationId);
+    }
+
+    @Override
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
         switch (key) {
             case "fabHide": {

--- a/app/src/main/res/layout/item_status_notification.xml
+++ b/app/src/main/res/layout/item_status_notification.xml
@@ -40,11 +40,50 @@
 
     </RelativeLayout>
 
+    <com.keylesspalace.tusky.view.FlowLayout
+        android:id="@+id/notification_content_warning_bar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/notification_top_bar"
+        android:layout_marginBottom="4dp"
+        android:layout_toEndOf="@+id/notification_status_avatar"
+        android:layout_toRightOf="@+id/notification_status_avatar"
+        android:focusable="true"
+        android:visibility="gone"
+        app:paddingHorizontal="4dp"
+        tools:visibility="visible">
+
+        <TextView
+            android:id="@+id/notification_content_warning_description"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="?android:textColorTertiary"
+            tools:text="Example CW text"/>
+
+        <ToggleButton
+            android:id="@+id/notification_content_warning_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="6dp"
+            android:background="?attr/content_warning_button"
+            android:minHeight="0dp"
+            android:minWidth="0dp"
+            android:paddingBottom="3dp"
+            android:paddingLeft="6dp"
+            android:paddingRight="6dp"
+            android:paddingTop="3dp"
+            android:textAllCaps="true"
+            android:textOff="@string/status_content_warning_show_more"
+            android:textOn="@string/status_content_warning_show_less"
+            android:textSize="12sp" />
+
+    </com.keylesspalace.tusky.view.FlowLayout>
+
     <TextView
         android:id="@+id/notification_content"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@id/notification_top_bar"
+        android:layout_below="@id/notification_content_warning_bar"
         android:paddingBottom="10dp"
         android:paddingEnd="0dp"
         android:paddingLeft="58dp"
@@ -57,7 +96,7 @@
         android:id="@+id/notification_status_avatar"
         android:layout_width="48dp"
         android:layout_height="48dp"
-        android:layout_alignTop="@id/notification_content"
+        android:layout_below="@id/notification_top_bar"
         android:layout_marginBottom="8dp"
         android:layout_marginEnd="10dp"
         android:layout_marginRight="10dp"


### PR DESCRIPTION
I'm sorry, I'm doing non-planned things again but this was *so annoying*.

So, in summary:
* Notifications now work like boosts in timelines - clicking on a status opens the status, clicking on the message on the top opens account of the person who caused the notification.
* CWs now work like they do in the web version. Firstly, they're hidden in the notifications by default and user can trigger them. Secondly, when content is hidden mentions are still visible (when should do the same for timelines, code will stay pretty much the same).

Please, review!
(closes #322, partly #292)