### PR TITLE
Save reply info in draft, refactor

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.application'
+apply plugin: 'kotlin-kapt'
 apply plugin: 'kotlin-android'
 
 android {
@@ -65,13 +66,14 @@ dependencies {
     compile 'com.evernote:android-job:1.2.0'
     implementation 'com.android.support.constraint:constraint-layout:1.0.2'
     //room
-    compile 'android.arch.persistence.room:runtime:1.0.0'
-    annotationProcessor 'android.arch.persistence.room:compiler:1.0.0'
-    testCompile 'junit:junit:4.12'
+    implementation "android.arch.persistence.room:runtime:1.0.0"
+    kapt 'android.arch.persistence.room:compiler:1.0.0'
+
+    testCompile "junit:junit:4.12"
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
 }
 repositories {
     mavenCentral()

--- a/app/src/main/java/com/keylesspalace/tusky/TuskyApplication.java
+++ b/app/src/main/java/com/keylesspalace/tusky/TuskyApplication.java
@@ -56,6 +56,7 @@ public class TuskyApplication extends Application {
         db = Room.databaseBuilder(getApplicationContext(), AppDatabase.class, "tuskyDB")
                 .allowMainThreadQueries()
                 .addMigrations(AppDatabase.MIGRATION_2_3)
+                .addMigrations(AppDatabase.MIGRATION_3_4)
                 .build();
 
         JobManager.create(this).addJobCreator(new NotificationPullJobCreator(this));

--- a/app/src/main/java/com/keylesspalace/tusky/adapter/MentionAutoCompleteAdapter.java
+++ b/app/src/main/java/com/keylesspalace/tusky/adapter/MentionAutoCompleteAdapter.java
@@ -1,0 +1,143 @@
+/* Copyright 2017 Andrew Dawson
+ *
+ * This file is a part of Tusky.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Tusky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Tusky; if not,
+ * see <http://www.gnu.org/licenses>. */
+
+package com.keylesspalace.tusky.adapter;
+
+import android.content.Context;
+import android.support.annotation.LayoutRes;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.Filter;
+import android.widget.Filterable;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import com.keylesspalace.tusky.R;
+import com.keylesspalace.tusky.entity.Account;
+import com.keylesspalace.tusky.view.RoundedTransformation;
+import com.squareup.picasso.Picasso;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by charlag on 12/11/17.
+ */
+
+public class MentionAutoCompleteAdapter extends ArrayAdapter<Account>
+        implements Filterable {
+    private ArrayList<Account> resultList;
+    @LayoutRes
+    private int layoutId;
+    private final AccountSearchProvider accountSearchProvider;
+
+    public MentionAutoCompleteAdapter(Context context, @LayoutRes int resource,
+                               AccountSearchProvider accountSearchProvider) {
+        super(context, resource);
+        layoutId = resource;
+        resultList = new ArrayList<>();
+        this.accountSearchProvider = accountSearchProvider;
+    }
+
+    @Override
+    public int getCount() {
+        return resultList.size();
+    }
+
+    @Override
+    public Account getItem(int index) {
+        return resultList.get(index);
+    }
+
+    @Override
+    @NonNull
+    public Filter getFilter() {
+        return new Filter() {
+            @Override
+            public CharSequence convertResultToString(Object resultValue) {
+                return ((Account) resultValue).username;
+            }
+
+            // This method is invoked in a worker thread.
+            @Override
+            protected FilterResults performFiltering(CharSequence constraint) {
+                FilterResults filterResults = new FilterResults();
+                if (constraint != null) {
+                    List<Account> accounts =
+                            accountSearchProvider.searchAccounts(constraint.toString());
+                    filterResults.values = accounts;
+                    filterResults.count = accounts.size();
+                }
+                return filterResults;
+            }
+
+            @SuppressWarnings("unchecked")
+            @Override
+            protected void publishResults(CharSequence constraint, FilterResults results) {
+                if (results != null && results.count > 0) {
+                    resultList.clear();
+                    ArrayList<Account> newResults = (ArrayList<Account>) results.values;
+                    resultList.addAll(newResults);
+                    notifyDataSetChanged();
+                } else {
+                    notifyDataSetInvalidated();
+                }
+            }
+        };
+    }
+
+    @Override
+    @NonNull
+    public View getView(int position, @Nullable View convertView, @NonNull ViewGroup parent) {
+        View view = convertView;
+
+        Context context = getContext();
+
+        if (convertView == null) {
+            LayoutInflater layoutInflater =
+                    (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+            //noinspection ConstantConditions
+            view = layoutInflater.inflate(layoutId, parent, false);
+        }
+
+        Account account = getItem(position);
+        if (account != null) {
+            TextView username = view.findViewById(R.id.username);
+            TextView displayName = view.findViewById(R.id.display_name);
+            ImageView avatar = view.findViewById(R.id.avatar);
+            String format = getContext().getString(R.string.status_username_format);
+            String formattedUsername = String.format(format, account.username);
+            username.setText(formattedUsername);
+            displayName.setText(account.getDisplayName());
+            if (!account.avatar.isEmpty()) {
+                Picasso.with(context)
+                        .load(account.avatar)
+                        .placeholder(R.drawable.avatar_default)
+                        .transform(new RoundedTransformation(7, 0))
+                        .into(avatar);
+            }
+        }
+
+        return view;
+    }
+
+    public interface AccountSearchProvider {
+        List<Account> searchAccounts(String mention);
+    }
+}

--- a/app/src/main/java/com/keylesspalace/tusky/db/AppDatabase.java
+++ b/app/src/main/java/com/keylesspalace/tusky/db/AppDatabase.java
@@ -1,25 +1,39 @@
+/* Copyright 2017 Andrew Dawson
+ *
+ * This file is a part of Tusky.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Tusky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Tusky; if not,
+ * see <http://www.gnu.org/licenses>. */
+
 package com.keylesspalace.tusky.db;
 
 import android.arch.persistence.db.SupportSQLiteDatabase;
 import android.arch.persistence.room.Database;
 import android.arch.persistence.room.RoomDatabase;
 import android.arch.persistence.room.migration.Migration;
+import android.support.annotation.NonNull;
 
 /**
  * DB version & declare DAO
  */
 
-@Database(entities = {TootEntity.class}, version = 3, exportSchema = false)
+@Database(entities = {TootEntity.class}, version = 4, exportSchema = false)
 public abstract class AppDatabase extends RoomDatabase {
 
     public abstract TootDao tootDao();
 
     public static final Migration MIGRATION_2_3 = new Migration(2, 3) {
         @Override
-        public void migrate(SupportSQLiteDatabase database) {
-            //this migration is necessary because of a change in the room library
+        public void migrate(@NonNull SupportSQLiteDatabase database) {
             database.execSQL("CREATE TABLE TootEntity2 (uid INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, text TEXT, urls TEXT, contentWarning TEXT);");
-
             database.execSQL("INSERT INTO TootEntity2 SELECT * FROM TootEntity;");
             database.execSQL("DROP TABLE TootEntity;");
             database.execSQL("ALTER TABLE TootEntity2 RENAME TO TootEntity;");
@@ -27,4 +41,13 @@ public abstract class AppDatabase extends RoomDatabase {
         }
     };
 
+    public static final Migration MIGRATION_3_4 = new Migration(3, 4) {
+        @Override
+        public void migrate(@NonNull SupportSQLiteDatabase database) {
+            database.execSQL("ALTER TABLE TootEntity ADD COLUMN inReplyToId TEXT");
+            database.execSQL("ALTER TABLE TootEntity ADD COLUMN inReplyToText TEXT");
+            database.execSQL("ALTER TABLE TootEntity ADD COLUMN inReplyToUsername TEXT");
+            database.execSQL("ALTER TABLE TootEntity ADD COLUMN visibility INTEGER");
+        }
+    };
 }

--- a/app/src/main/java/com/keylesspalace/tusky/db/TootDao.java
+++ b/app/src/main/java/com/keylesspalace/tusky/db/TootDao.java
@@ -1,33 +1,43 @@
+/* Copyright 2017 Andrew Dawson
+ *
+ * This file is a part of Tusky.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Tusky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Tusky; if not,
+ * see <http://www.gnu.org/licenses>. */
+
 package com.keylesspalace.tusky.db;
 
 import android.arch.persistence.room.Dao;
-import android.arch.persistence.room.Delete;
 import android.arch.persistence.room.Insert;
+import android.arch.persistence.room.OnConflictStrategy;
 import android.arch.persistence.room.Query;
+import android.arch.persistence.room.Transaction;
 import android.arch.persistence.room.Update;
 
 import java.util.List;
 
 /**
  * Created by cto3543 on 28/06/2017.
- * crud interface on this Toot DB
+ *
+ * DAO to fetch and update toots in the DB.
  */
 
 @Dao
 public interface TootDao {
-    // c
-    @Insert
-    long insert(TootEntity users);
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    void insertOrReplace(TootEntity users);
 
-    // r
-    @Query("SELECT * FROM TootEntity")
+    @Query("SELECT * FROM TootEntity ORDER BY uid DESC")
     List<TootEntity> loadAll();
 
-    // u
-    @Update
-    void updateToot(TootEntity toot);
-
-    // d
-    @Delete
-    int delete(TootEntity user);
+    @Query("DELETE FROM TootEntity WHERE uid = :uid")
+    int delete(int uid);
 }

--- a/app/src/main/java/com/keylesspalace/tusky/db/TootEntity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/db/TootEntity.java
@@ -1,57 +1,119 @@
+/* Copyright 2017 Andrew Dawson
+ *
+ * This file is a part of Tusky.
+ *
+ * This program is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Tusky is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with Tusky; if not,
+ * see <http://www.gnu.org/licenses>. */
+
 package com.keylesspalace.tusky.db;
 
 import android.arch.persistence.room.ColumnInfo;
 import android.arch.persistence.room.Entity;
 import android.arch.persistence.room.PrimaryKey;
+import android.arch.persistence.room.TypeConverter;
+import android.arch.persistence.room.TypeConverters;
+import android.support.annotation.Nullable;
+
+import com.keylesspalace.tusky.entity.Status;
 
 /**
- * toot model
+ * Toot model.
  */
 
 @Entity
+@TypeConverters(TootEntity.Converters.class)
 public class TootEntity {
     @PrimaryKey(autoGenerate = true)
-    private int uid;
+    private final int uid;
 
     @ColumnInfo(name = "text")
-    private String text;
+    private final String text;
 
     @ColumnInfo(name = "urls")
-    private String urls;
+    private final String urls;
 
     @ColumnInfo(name = "contentWarning")
-    private String contentWarning;
+    private final String contentWarning;
 
-    // getter setter
-    public String getText() {
-        return text;
+    @ColumnInfo(name = "inReplyToId")
+    private final String inReplyToId;
+
+    @Nullable
+    @ColumnInfo(name = "inReplyToText")
+    private final String inReplyToText;
+
+    @Nullable
+    @ColumnInfo(name = "inReplyToUsername")
+    private final String inReplyToUsername;
+
+    @ColumnInfo(name = "visibility")
+    private final Status.Visibility visibility;
+
+    public TootEntity(int uid, String text, String urls, String contentWarning, String inReplyToId,
+                      @Nullable String inReplyToText, @Nullable String inReplyToUsername,
+                      Status.Visibility visibility) {
+        this.uid = uid;
+        this.text = text;
+        this.urls = urls;
+        this.contentWarning = contentWarning;
+        this.inReplyToId = inReplyToId;
+        this.inReplyToText = inReplyToText;
+        this.inReplyToUsername = inReplyToUsername;
+        this.visibility = visibility;
     }
 
-    public void setText(String text) {
-        this.text = text;
+    public String getText() {
+        return text;
     }
 
     public String getContentWarning() {
         return contentWarning;
     }
 
-    public void setContentWarning(String contentWarning) {
-        this.contentWarning = contentWarning;
-    }
-
     public int getUid() {
         return uid;
-    }
-
-    public void setUid(int uid) {
-        this.uid = uid;
     }
 
     public String getUrls() {
         return urls;
     }
 
-    public void setUrls(String urls) {
-        this.urls = urls;
+    public String getInReplyToId() {
+        return inReplyToId;
+    }
+
+    @Nullable
+    public String getInReplyToText() {
+        return inReplyToText;
+    }
+
+    @Nullable
+    public String getInReplyToUsername() {
+        return inReplyToUsername;
+    }
+
+    public Status.Visibility getVisibility() {
+        return visibility;
+    }
+
+    public static final class Converters {
+
+        @TypeConverter
+        public Status.Visibility visibilityFromInt(int number) {
+            return Status.Visibility.byNum(number);
+        }
+
+        @TypeConverter
+        public int intToVisibility(Status.Visibility visibility) {
+            return visibility.getNum();
+        }
     }
 }

--- a/app/src/main/java/com/keylesspalace/tusky/entity/Status.java
+++ b/app/src/main/java/com/keylesspalace/tusky/entity/Status.java
@@ -50,15 +50,45 @@ public class Status {
     }
 
     public enum Visibility {
-        UNKNOWN,
+        UNKNOWN(0),
         @SerializedName("public")
-        PUBLIC,
+        PUBLIC(1),
         @SerializedName("unlisted")
-        UNLISTED,
+        UNLISTED(2),
         @SerializedName("private")
-        PRIVATE,
+        PRIVATE(3),
         @SerializedName("direct")
-        DIRECT,
+        DIRECT(4);
+
+        private final int num;
+
+        Visibility(int num) {
+            this.num = num;
+        }
+
+        public int getNum() {
+            return num;
+        }
+
+        public static Visibility byNum(int num) {
+            switch (num) {
+                case 4: return DIRECT;
+                case 3: return PRIVATE;
+                case 2: return UNLISTED;
+                case 1: return PUBLIC;
+                case 0: default: return UNKNOWN;
+            }
+        }
+
+        public String serverString() {
+            switch (this) {
+                case PUBLIC: return "public";
+                case UNLISTED: return "unlisted";
+                case PRIVATE: return "private";
+                case DIRECT: return "direct";
+                case UNKNOWN: default: return "unknown";
+            }
+        }
     }
 
     public String id;
@@ -162,7 +192,7 @@ public class Status {
         }
     }
 
-    public static class Mention {
+    public static final class Mention {
         public String id;
 
         public String url;
@@ -179,6 +209,7 @@ public class Status {
         public String website;
     }
 
+    @SuppressWarnings("unused")
     public static class Emoji {
         private String shortcode;
         private String url;

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/ComposeOptionsFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/ComposeOptionsFragment.java
@@ -34,11 +34,12 @@ import android.widget.RadioButton;
 import android.widget.RadioGroup;
 
 import com.keylesspalace.tusky.R;
+import com.keylesspalace.tusky.entity.Status;
 import com.keylesspalace.tusky.util.ThemeUtils;
 
 public class ComposeOptionsFragment extends BottomSheetDialogFragment {
     public interface Listener {
-        void onVisibilityChanged(String visibility);
+        void onVisibilityChanged(Status.Visibility visibility);
         void onContentWarningChanged(boolean hideText);
     }
 
@@ -46,10 +47,10 @@ public class ComposeOptionsFragment extends BottomSheetDialogFragment {
     private CheckBox hideText;
     private Listener listener;
 
-    public static ComposeOptionsFragment newInstance(String visibility, boolean hideText) {
+    public static ComposeOptionsFragment newInstance(Status.Visibility visibility, boolean hideText) {
         Bundle arguments = new Bundle();
         ComposeOptionsFragment fragment = new ComposeOptionsFragment();
-        arguments.putString("visibility", visibility);
+        arguments.putInt("visibilityNum", visibility.getNum());
         arguments.putBoolean("hideText", hideText);
         fragment.setArguments(arguments);
         return fragment;
@@ -68,18 +69,18 @@ public class ComposeOptionsFragment extends BottomSheetDialogFragment {
         View rootView = inflater.inflate(R.layout.fragment_compose_options, container, false);
 
         Bundle arguments = getArguments();
-        String statusVisibility = arguments.getString("visibility");
+        Status.Visibility visibility = Status.Visibility.byNum(
+                arguments.getInt("visibilityNum", 0)
+        );
         boolean statusHideText = arguments.getBoolean("hideText");
 
         radio = rootView.findViewById(R.id.radio_visibility);
         int radioCheckedId = R.id.radio_public;
-        if (statusVisibility != null) {
-            switch (statusVisibility) {
-                case "public":   radioCheckedId = R.id.radio_public;   break;
-                case "private":  radioCheckedId = R.id.radio_private;  break;
-                case "unlisted": radioCheckedId = R.id.radio_unlisted; break;
-                case "direct":   radioCheckedId = R.id.radio_direct;   break;
-            }
+        switch (visibility) {
+            case PUBLIC:   radioCheckedId = R.id.radio_public;   break;
+            case PRIVATE:  radioCheckedId = R.id.radio_private;  break;
+            case UNLISTED: radioCheckedId = R.id.radio_unlisted; break;
+            case DIRECT:   radioCheckedId = R.id.radio_direct;   break;
         }
         radio.check(radioCheckedId);
 
@@ -104,23 +105,23 @@ public class ComposeOptionsFragment extends BottomSheetDialogFragment {
         radio.setOnCheckedChangeListener(new RadioGroup.OnCheckedChangeListener() {
             @Override
             public void onCheckedChanged(RadioGroup group, int checkedId) {
-                String visibility;
+                Status.Visibility visibility;
                 switch (checkedId) {
                     default:
                     case R.id.radio_public: {
-                        visibility = "public";
+                        visibility = Status.Visibility.PUBLIC;
                         break;
                     }
                     case R.id.radio_unlisted: {
-                        visibility = "unlisted";
+                        visibility = Status.Visibility.UNLISTED;
                         break;
                     }
                     case R.id.radio_private: {
-                        visibility = "private";
+                        visibility = Status.Visibility.PRIVATE;
                         break;
                     }
                     case R.id.radio_direct: {
-                        visibility = "direct";
+                        visibility = Status.Visibility.DIRECT;
                         break;
                     }
                 }

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/SFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/SFragment.java
@@ -93,7 +93,7 @@ public abstract class SFragment extends BaseFragment implements AdapterItemRemov
     protected void reply(Status status) {
         String inReplyToId = status.getActionableId();
         Status actionableStatus = status.getActionableStatus();
-        String replyVisibility = actionableStatus.getVisibility().toString().toLowerCase();
+        Status.Visibility replyVisibility = actionableStatus.getVisibility();
         String contentWarning = actionableStatus.spoilerText;
         Status.Mention[] mentions = actionableStatus.mentions;
         List<String> mentionedUsernames = new ArrayList<>();
@@ -107,7 +107,7 @@ public abstract class SFragment extends BaseFragment implements AdapterItemRemov
                 .replyVisibility(replyVisibility)
                 .contentWarning(contentWarning)
                 .mentionedUsernames(mentionedUsernames)
-                .repyingStatusAuthor(actionableStatus.account)
+                .repyingStatusAuthor(actionableStatus.account.localUsername)
                 .replyingStatusContent(actionableStatus.content.toString())
                 .build(getContext());
         startActivityForResult(intent, COMPOSE_RESULT);

--- a/app/src/main/java/com/keylesspalace/tusky/fragment/ViewThreadFragment.java
+++ b/app/src/main/java/com/keylesspalace/tusky/fragment/ViewThreadFragment.java
@@ -320,9 +320,9 @@ public class ViewThreadFragment extends SFragment implements
         call.enqueue(new Callback<StatusContext>() {
             @Override
             public void onResponse(@NonNull Call<StatusContext> call, @NonNull Response<StatusContext> response) {
-                if (response.isSuccessful()) {
+                StatusContext context = response.body();
+                if (response.isSuccessful() && context != null) {
                     swipeRefreshLayout.setRefreshing(false);
-                    StatusContext context = response.body();
                     setContext(context.ancestors, context.descendants);
                 } else {
                     onThreadRequestFailure(id);

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -138,6 +138,7 @@
     <string name="dialog_download_image">Скачать</string>
     <string name="dialog_message_follow_request">Статус запроса на подписку: ожидается ответ</string>
     <string name="dialog_unfollow_warning">Отписаться от этого аккаунта?</string>
+    <string name="dialog_reply_not_found">Не удалось опубликовать статус. Статус, на который вы отвечаете, может быть недоступен. Убрать информацию об ответе?</string>
 
     <string name="visibility_public">Публичный: Показать в публичных лентах</string>
     <string name="visibility_unlisted">Скрытый: Не показывать в лентах</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -146,6 +146,7 @@
     <string name="dialog_download_image">Download</string>
     <string name="dialog_message_follow_request">Follow request pending: awaiting their response</string>
     <string name="dialog_unfollow_warning">Unfollow this account?</string>
+    <string name="dialog_reply_not_found">Couldn\'t post this status. The status you\'re replying to might not be available. Remove reply info?</string>
 
     <string name="visibility_public">Public: Post to public timelines</string>
     <string name="visibility_unlisted">Unlisted: Do not show in public timelines</string>


### PR DESCRIPTION
This fixes #417 and closes #440 and there's also a little bit of refactoring.
I actually did much more than I should have done first. I've tried saving ```Mention```s but turns out I didn't need them for this. It would be a good idea to save the toot we're replying to but the DB is not ready yet for such thing. So I've just added some fields and that's it.
I didn't understand the visibility logic first. I hope I didn't break anything.
I've tried to remove as much as possible from ```ComposeActivity``` because it's huge.
Sorry that it's all smashed together but it's mostly related things.