### PR TITLE
implement support for HTTP proxy

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/BaseActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/BaseActivity.java
@@ -137,8 +137,10 @@ public abstract class BaseActivity extends AppCompatActivity {
                 .registerTypeAdapter(Spanned.class, new SpannedTypeAdapter())
                 .create();
 
+        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(this);
+
         OkHttpClient.Builder okBuilder =
-                OkHttpUtils.getCompatibleClientBuilder()
+                OkHttpUtils.getCompatibleClientBuilder(preferences)
                         .addInterceptor(new AuthInterceptor(this))
                         .dispatcher(mastodonApiDispatcher);
 

--- a/app/src/main/java/com/keylesspalace/tusky/LoginActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/LoginActivity.java
@@ -152,7 +152,7 @@ public class LoginActivity extends AppCompatActivity {
     private MastodonApi getApiFor(String domain) {
         Retrofit retrofit = new Retrofit.Builder()
                 .baseUrl("https://" + domain)
-                .client(OkHttpUtils.getCompatibleClient())
+                .client(OkHttpUtils.getCompatibleClient(preferences))
                 .addConverterFactory(GsonConverterFactory.create())
                 .build();
 

--- a/app/src/main/java/com/keylesspalace/tusky/NotificationPullJobCreator.java
+++ b/app/src/main/java/com/keylesspalace/tusky/NotificationPullJobCreator.java
@@ -76,8 +76,10 @@ public final class NotificationPullJobCreator implements JobCreator {
     }
 
     private static MastodonApi createMastodonApi(String domain, Context context) {
+        SharedPreferences preferences = context.getSharedPreferences(
+                context.getString(R.string.preferences_file_key), Context.MODE_PRIVATE);
 
-        OkHttpClient okHttpClient = OkHttpUtils.getCompatibleClientBuilder()
+        OkHttpClient okHttpClient = OkHttpUtils.getCompatibleClientBuilder(preferences)
                 .addInterceptor(new AuthInterceptor(context))
                 .build();
 

--- a/app/src/main/java/com/keylesspalace/tusky/TuskyApplication.java
+++ b/app/src/main/java/com/keylesspalace/tusky/TuskyApplication.java
@@ -17,6 +17,8 @@ package com.keylesspalace.tusky;
 
 import android.app.Application;
 import android.arch.persistence.room.Room;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
 import android.support.v7.app.AppCompatDelegate;
 
 import com.evernote.android.job.JobManager;
@@ -37,7 +39,8 @@ public class TuskyApplication extends Application {
         super.onCreate();
         // Initialize Picasso configuration
         Picasso.Builder builder = new Picasso.Builder(this);
-        builder.downloader(new OkHttp3Downloader(OkHttpUtils.getCompatibleClient()));
+        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(this);
+        builder.downloader(new OkHttp3Downloader(OkHttpUtils.getCompatibleClient(preferences)));
         if (BuildConfig.DEBUG) {
             builder.listener((picasso, uri, exception) -> exception.printStackTrace());
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -177,6 +177,11 @@
     <string name="pref_title_show_boosts">Show boosts</string>
     <string name="pref_title_show_replies">Show replies</string>
     <string name="pref_title_show_media_preview">Show media previews</string>
+    <string name="pref_title_proxy_settings">Proxy</string>
+    <string name="pref_title_http_proxy_settings">HTTP proxy</string>
+    <string name="pref_title_http_proxy_enable">Enable HTTP proxy</string>
+    <string name="pref_title_http_proxy_server">HTTP proxy server</string>
+    <string name="pref_title_http_proxy_port">HTTP proxy port</string>
 
     <string-array name="pull_notification_check_interval_names">
         <item>15 minutes</item>

--- a/app/src/main/res/xml/http_proxy_preferences.xml
+++ b/app/src/main/res/xml/http_proxy_preferences.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen android:title="@string/pref_title_http_proxy_settings"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <CheckBoxPreference
+        android:defaultValue="true"
+        android:key="httpProxyEnabled"
+        android:title="@string/pref_title_http_proxy_enable" />
+    <EditTextPreference
+        android:key="httpProxyServer"
+        android:title="@string/pref_title_http_proxy_server"
+        android:summary="%s" />
+    <EditTextPreference
+        android:key="httpProxyPort"
+        android:title="@string/pref_title_http_proxy_port"
+        android:summary="%s" />
+
+</PreferenceScreen>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -74,4 +74,12 @@
             android:title="@string/pref_title_edit_notification_settings" />
 
     </PreferenceCategory>
+
+    <PreferenceCategory android:title="@string/pref_title_proxy_settings">
+        <Preference
+            android:key="httpProxyPreferences"
+            android:summary="%s"
+            android:title="@string/pref_title_http_proxy_settings" />
+
+    </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
This change allows the user to manually enter an unauthenticated proxy
configuration to be used for all API connections. This is mainly
intended for using Tusky with Tor (via Orbot or a local proxy).