### PR TITLE
Privacy enhancement: option in preferences to enable Secure Screen

### DIFF
--- a/app/src/main/java/com/keylesspalace/tusky/BaseActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/BaseActivity.java
@@ -28,6 +28,7 @@ import android.support.v7.app.AppCompatActivity;
 import android.text.Spanned;
 import android.util.TypedValue;
 import android.view.Menu;
+import android.view.WindowManager;
 
 import com.evernote.android.job.JobManager;
 import com.evernote.android.job.JobRequest;
@@ -72,6 +73,12 @@ public abstract class BaseActivity extends AppCompatActivity {
         if (flavor.equals(ThemeUtils.THEME_FLAVOR_DEFAULT))
             flavor = themeFlavorPreference;
         ThemeUtils.setAppNightMode(flavor);
+
+        boolean secureScreen = preferences.getBoolean("secureScreen", false);
+        if (secureScreen)
+            getWindow().addFlags(WindowManager.LayoutParams.FLAG_SECURE);
+        else
+            getWindow().clearFlags(WindowManager.LayoutParams.FLAG_SECURE);
 
         int style;
         switch(preferences.getString("statusTextSize", "medium")) {

--- a/app/src/main/java/com/keylesspalace/tusky/PreferencesActivity.java
+++ b/app/src/main/java/com/keylesspalace/tusky/PreferencesActivity.java
@@ -25,6 +25,7 @@ import android.support.annotation.XmlRes;
 import android.support.v7.app.ActionBar;
 import android.support.v7.widget.Toolbar;
 import android.view.MenuItem;
+import android.view.WindowManager;
 
 import com.keylesspalace.tusky.fragment.PreferencesFragment;
 import com.keylesspalace.tusky.util.ResourcesUtils;
@@ -167,6 +168,14 @@ public class PreferencesActivity extends BaseActivity
             }
             case "statusTextSize": {
                 restartActivitiesOnExit = true;
+                break;
+            }
+            case "secureScreen": {
+                boolean secure = sharedPreferences.getBoolean("secureScreen", false);
+                if (secure)
+                    getWindow().addFlags(WindowManager.LayoutParams.FLAG_SECURE);
+                else
+                    getWindow().clearFlags(WindowManager.LayoutParams.FLAG_SECURE);
                 break;
             }
             case "notificationsEnabled": {

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -158,7 +158,6 @@
     <string name="pref_title_status_tabs">الألسنة</string>
     <string name="pref_title_show_boosts">عرض الترقيات</string>
     <string name="pref_title_show_replies">عرض الردود</string>
-    <string name="pref_title_proxy_settings">البروكسي</string>
     <string name="pref_title_http_proxy_settings">بروكسي HTTP</string>
     <string name="pref_title_http_proxy_enable">تفعيل بروكسي HTTP</string>
     <string name="pref_title_http_proxy_server">خادوم بروكسي HTTP</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -166,6 +166,8 @@
         <item>Dzień</item>
     </string-array>
 
+    <string name="pref_title_privacy_settings">Prywatność</string>
+    <string name="pref_secure_screen">Zapobiegaj zrzutom ekranu</string>
     <string name="pref_title_browser_settings">Przeglądarka</string>
     <string name="pref_title_custom_tabs">Używaj niestandardowych kart Chrome</string>
     <string name="pref_title_hide_follow_button">Ukryj przycisk obserwacji podczas przewijania</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -167,7 +167,7 @@
     </string-array>
 
     <string name="pref_title_privacy_settings">Prywatność</string>
-    <string name="pref_secure_screen">Zapobiegaj zrzutom ekranu</string>
+    <string name="pref_title_secure_screen">Zapobiegaj zrzutom ekranu</string>
     <string name="pref_title_browser_settings">Przeglądarka</string>
     <string name="pref_title_custom_tabs">Używaj niestandardowych kart Chrome</string>
     <string name="pref_title_hide_follow_button">Ukryj przycisk obserwacji podczas przewijania</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -190,7 +190,10 @@
     <string name="pref_title_show_boosts">Show boosts</string>
     <string name="pref_title_show_replies">Show replies</string>
     <string name="pref_title_show_media_preview">Show media previews</string>
-    <string name="pref_title_proxy_settings">Proxy</string>
+    <string name="pref_title_privacy_settings">Privacy</string>
+    
+    <string name="pref_secure_screen">Prevent taking screenshots</string>
+    
     <string name="pref_title_http_proxy_settings">HTTP proxy</string>
     <string name="pref_title_http_proxy_enable">Enable HTTP proxy</string>
     <string name="pref_title_http_proxy_server">HTTP proxy server</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -191,9 +191,7 @@
     <string name="pref_title_show_replies">Show replies</string>
     <string name="pref_title_show_media_preview">Show media previews</string>
     <string name="pref_title_privacy_settings">Privacy</string>
-    
-    <string name="pref_secure_screen">Prevent taking screenshots</string>
-    
+    <string name="pref_title_secure_screen">Prevent taking screenshots</string>
     <string name="pref_title_http_proxy_settings">HTTP proxy</string>
     <string name="pref_title_http_proxy_enable">Enable HTTP proxy</string>
     <string name="pref_title_http_proxy_server">HTTP proxy server</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -89,7 +89,7 @@
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="secureScreen"
-            android:title="@string/pref_secure_screen" />
+            android:title="@string/pref_title_secure_screen" />
 
         <Preference
             android:key="httpProxyPreferences"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -85,7 +85,12 @@
 
     </PreferenceCategory>
 
-    <PreferenceCategory android:title="@string/pref_title_proxy_settings">
+    <PreferenceCategory android:title="@string/pref_title_privacy_settings">
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="secureScreen"
+            android:title="@string/pref_secure_screen" />
+
         <Preference
             android:key="httpProxyPreferences"
             android:summary="%s"


### PR DESCRIPTION
From user's perspective, Secure Screen prevents other apps (and users themselves) to take screenshots of Activities affected with that flag. It also hides application content preview from recents menu.

You'll still be able to launch application without authenticating.

This patch was tested under Android Lollipop 5.1 and Android Oreo 8.1. It's worth mentioning that on L it requires application to restart to apply that flag.

![Feature preview](https://mastodon.social/media/PCiqvXOsW6SgwqwbExs)